### PR TITLE
set maxUnavailable to 33% for fluentd

### DIFF
--- a/apps/fluentd-cloudwatch/daemonset.yaml
+++ b/apps/fluentd-cloudwatch/daemonset.yaml
@@ -11,7 +11,7 @@ spec:
       app: fluentd-cloudwatch
   updateStrategy:
     rollingUpdate:
-      maxUnavailable: 33%
+      maxUnavailable: 100%
   template:
     metadata:
       labels:

--- a/apps/fluentd-cloudwatch/daemonset.yaml
+++ b/apps/fluentd-cloudwatch/daemonset.yaml
@@ -9,6 +9,9 @@ spec:
   selector:
     matchLabels:
       app: fluentd-cloudwatch
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 33%
   template:
     metadata:
       labels:


### PR DESCRIPTION
Instead of updating taking at least 30 seconds for each pod/node, it'll now spend 30 seconds-ish for 33% of the node capacity, so up to about 2 minutes to roll out an update.