### PR TITLE
Avoiding issue with Fluentd increasing buffer space utilization

### DIFF
--- a/apps/fluentd-cloudwatch/configmap.yaml
+++ b/apps/fluentd-cloudwatch/configmap.yaml
@@ -87,7 +87,10 @@ data:
         @type null
       </secondary>
       <buffer>
-        @type memory
+        @type file
+        chunk_limit_size 8MB # match memory buffer
+        total_limit_size 512MB # match memory buffer
+        flush_at_shutdown true # match memory buffer
         disable_chunk_backup true
         retry_forever false
         retry_timeout 10s

--- a/apps/fluentd-cloudwatch/configmap.yaml
+++ b/apps/fluentd-cloudwatch/configmap.yaml
@@ -90,16 +90,8 @@ data:
         @type file
         path /var/log/fluentd-buffer
         chunk_limit_size 256MB
-        total_limit_size 16GB
-        flush_at_shutdown true # match memory buffer
+        total_limit_size 8GB
+        flush_at_shutdown true
         disable_chunk_backup true
-        retry_forever false
-        retry_timeout 10s
-        retry_max_times 3
-        retry_type exponential_backoff
-        retry_wait 1s
-        retry_exponential_backoff_base 2
-        retry_max_interval 30s
-        retry_randomize true
       </buffer>
     </match>

--- a/apps/fluentd-cloudwatch/configmap.yaml
+++ b/apps/fluentd-cloudwatch/configmap.yaml
@@ -12,6 +12,12 @@ data:
   #@type null
   #</match>
 
+  00-logging.conf: |-
+    # Change the log level
+    <system>
+      log_level trace
+    </system>
+
   00-exceptions.conf: |-
     # Add an extra record with the original tag
     <filter raw.kubernetes.**>

--- a/apps/fluentd-cloudwatch/configmap.yaml
+++ b/apps/fluentd-cloudwatch/configmap.yaml
@@ -82,6 +82,10 @@ data:
       retention_in_days "#{ENV['RETENTION_IN_DAYS'] || 'nil'}"
       json_handler yajl # To avoid UndefinedConversionError
       log_rejected_request "#{ENV['LOG_REJECTED_REQUEST']}" # Log rejected request for missing parts
+      <secondary>
+        # On failure to flush, dump the chunk.
+        @type null
+      </secondary>
       <buffer>
         @type memory
         disable_chunk_backup true

--- a/apps/fluentd-cloudwatch/configmap.yaml
+++ b/apps/fluentd-cloudwatch/configmap.yaml
@@ -12,12 +12,6 @@ data:
   #@type null
   #</match>
 
-  00-logging.conf: |-
-    # Change the log level
-    <system>
-      log_level trace
-    </system>
-
   00-exceptions.conf: |-
     # Add an extra record with the original tag
     <filter raw.kubernetes.**>

--- a/apps/fluentd-cloudwatch/configmap.yaml
+++ b/apps/fluentd-cloudwatch/configmap.yaml
@@ -7,10 +7,10 @@ metadata:
     app: fluentd-cloudwatch
 data:
   #filters.conf: |-
-    # Discard kube-system namespace
-    #<match kubernetes.var.log.containers.**_kube-system_**>
-      #@type null
-    #</match>
+  # Discard kube-system namespace
+  #<match kubernetes.var.log.containers.**_kube-system_**>
+  #@type null
+  #</match>
 
   00-exceptions.conf: |-
     # Add an extra record with the original tag
@@ -82,4 +82,8 @@ data:
       retention_in_days "#{ENV['RETENTION_IN_DAYS'] || 'nil'}"
       json_handler yajl # To avoid UndefinedConversionError
       log_rejected_request "#{ENV['LOG_REJECTED_REQUEST']}" # Log rejected request for missing parts
+      <buffer>
+        @type memory
+        disable_chunk_backup true
+      </buffer>
     </match>

--- a/apps/fluentd-cloudwatch/configmap.yaml
+++ b/apps/fluentd-cloudwatch/configmap.yaml
@@ -89,8 +89,8 @@ data:
       <buffer>
         @type file
         path /var/log/fluentd-buffer
-        chunk_limit_size 8MB # match memory buffer
-        total_limit_size 512MB # match memory buffer
+        chunk_limit_size 256MB
+        total_limit_size 16GB
         flush_at_shutdown true # match memory buffer
         disable_chunk_backup true
         retry_forever false

--- a/apps/fluentd-cloudwatch/configmap.yaml
+++ b/apps/fluentd-cloudwatch/configmap.yaml
@@ -88,6 +88,7 @@ data:
       </secondary>
       <buffer>
         @type file
+        path /var/log/fluentd-buffer
         chunk_limit_size 8MB # match memory buffer
         total_limit_size 512MB # match memory buffer
         flush_at_shutdown true # match memory buffer

--- a/apps/fluentd-cloudwatch/configmap.yaml
+++ b/apps/fluentd-cloudwatch/configmap.yaml
@@ -85,5 +85,13 @@ data:
       <buffer>
         @type memory
         disable_chunk_backup true
+        retry_forever false
+        retry_timeout 10s
+        retry_max_times 3
+        retry_type exponential_backoff
+        retry_wait 1s
+        retry_exponential_backoff_base 2
+        retry_max_interval 30s
+        retry_randomize true
       </buffer>
     </match>

--- a/apps/fluentd-cloudwatch/daemonset.yaml
+++ b/apps/fluentd-cloudwatch/daemonset.yaml
@@ -59,15 +59,15 @@ spec:
               mountPath: /fluentd/etc/conf.d
               readOnly: false
           livenessProbe:
-              httpGet:
-                path: /metrics
-                port: 24231
-                scheme: HTTP
-              initialDelaySeconds: 30
-              timeoutSeconds: 10
-              periodSeconds: 15
-              successThreshold: 1
-              failureThreshold: 3
+            httpGet:
+              path: /metrics
+              port: 24231
+              scheme: HTTP
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
+            periodSeconds: 15
+            successThreshold: 1
+            failureThreshold: 3
       volumes:
         - name: varlog
           hostPath:


### PR DESCRIPTION
- Use the secondary output to discard chunks that fail to flush to CloudWatch
- Disable chunk backup of chunks that failed to flush
- Switch from an in-memory buffer to a file-based buffer
- Increase the total buffer size limit to 8 GB from 512 MB
- Increase the chunk size limit to 256 MB from 8 MB

---

The key seems to be increasing the chunk size limit without which it seems under heavy (larger than the chunk size limit per flush interval) load Fluentd is falling into some state that is causing it incorrectly account for its utilization of the buffer. The size it reports in those cases does not seem to match what one sees on disk.
