### PR TITLE
Remedy the a high logging rate from a given host.

### DIFF
--- a/apps/fluentd-cloudwatch/configmap.yaml
+++ b/apps/fluentd-cloudwatch/configmap.yaml
@@ -89,9 +89,12 @@ data:
       <buffer>
         @type file
         path /var/log/fluentd-buffer
-        chunk_limit_size 256MB
+        chunk_limit_size 64MB
         total_limit_size 8GB
         flush_at_shutdown true
+        flush_interval 15s
+        flush_thread_interval 1.0
+        flush_thread_burst_interval 0.3
         disable_chunk_backup true
       </buffer>
     </match>


### PR DESCRIPTION
- Reduce the flush_interval to 15s from 60s
- Reduce the chunk_limit_size proportionally to 64 MB
- Reduce the flush_thread_burst_interval to 0.3 from 1 to decrease the flush interval to ~5s when there are multiple chunks queued up.