### PR TITLE
Use new format for backupstoragelocation in the Velero helm chart

### DIFF
--- a/apps/velero/release.yaml
+++ b/apps/velero/release.yaml
@@ -29,7 +29,7 @@ spec:
       logLevel: info
       logFormat: json
       backupStorageLocation:
-      - provider: velero.io/aws
+      - provider: aws
         bucket: velero-storage
         config:
           region: eu-west-1

--- a/apps/velero/release.yaml
+++ b/apps/velero/release.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: velero
-      version: "2.23.12"
+      version: 4.0.3
       sourceRef:
         kind: HelmRepository
         name: vmware-tanzu
@@ -20,7 +20,7 @@ spec:
   values:
     image:
       name: velero/velero
-      tag: v1.5.3
+      tag: v1.11.0
     cleanUpCRDs: true
     credentials:
       useSecret: false
@@ -40,16 +40,16 @@ spec:
           region: eu-west-1
     initContainers:
       - name: velero-plugin-for-aws
-        image: velero/velero-plugin-for-aws:v1.2.0
+        image: velero/velero-plugin-for-aws:v1.7.0
         volumeMounts:
           - mountPath: /target
             name: plugins
       - name: velero-plugin-for-csi
-        image: velero/velero-plugin-for-csi:v0.1.2
+        image: velero/velero-plugin-for-csi:v0.5.0
         volumeMounts:
           - mountPath: /target
             name: plugins
-    priorityClassName: "service-critical"
+    priorityClassName: service-critical
     metrics:
       serviceMonitor:
         enabled: true

--- a/apps/velero/release.yaml
+++ b/apps/velero/release.yaml
@@ -28,15 +28,17 @@ spec:
     configuration:
       logLevel: info
       logFormat: json
-      provider: aws
       backupStorageLocation:
-        bucket: velero-storage
-        config:
-          region: eu-west-1
+        - name: velero-storage
+          provider: aws
+          bucket: velero-storage
+          config:
+            region: eu-west-1
       volumeSnapshotLocation:
-        name: velero-snapshot
-        config:
-          region: eu-west-1
+        - name: velero-snapshot
+          provider: aws
+          config:
+            region: eu-west-1
     initContainers:
       - name: velero-plugin-for-aws
         image: velero/velero-plugin-for-aws:v1.2.0

--- a/apps/velero/release.yaml
+++ b/apps/velero/release.yaml
@@ -29,8 +29,7 @@ spec:
       logLevel: info
       logFormat: json
       backupStorageLocation:
-      - name: velero-storage
-        provider: velero.io/aws
+      - provider: velero.io/aws
         bucket: velero-storage
         config:
           region: eu-west-1

--- a/apps/velero/release.yaml
+++ b/apps/velero/release.yaml
@@ -30,7 +30,7 @@ spec:
       logFormat: json
       backupStorageLocation:
       - name: velero-storage
-        provider: aws
+        provider: velero.io/aws
         bucket: velero-storage
         config:
           region: eu-west-1

--- a/apps/velero/release.yaml
+++ b/apps/velero/release.yaml
@@ -29,16 +29,16 @@ spec:
       logLevel: info
       logFormat: json
       backupStorageLocation:
-        - name: velero-storage
-          provider: aws
-          bucket: velero-storage
-          config:
-            region: eu-west-1
+      - name: velero-storage
+        provider: aws
+        bucket: velero-storage
+        config:
+          region: eu-west-1
       volumeSnapshotLocation:
-        - name: velero-snapshot
-          provider: aws
-          config:
-            region: eu-west-1
+      - name: velero-snapshot
+        provider: aws
+        config:
+          region: eu-west-1
     initContainers:
       - name: velero-plugin-for-aws
         image: velero/velero-plugin-for-aws:v1.2.0


### PR DESCRIPTION
- Change the map to a slice
- Just a bit of formatting
- Change provider name
- Use default name for backup storage location
- Change provider name
- Fix linter issue, and align config with latest Helm chart
