### PR TITLE
Enforcing new pod security standards

### DIFF
--- a/apps/datadog-operator/namespace.yaml
+++ b/apps/datadog-operator/namespace.yaml
@@ -3,5 +3,4 @@ kind: Namespace
 metadata:
   name: datadog
   labels:
-    pod-security.kubernetes.io/audit: baseline
-    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/enforce: baseline

--- a/apps/fluentd-cloudwatch/namespace.yaml
+++ b/apps/fluentd-cloudwatch/namespace.yaml
@@ -3,5 +3,4 @@ kind: Namespace
 metadata:
   name: fluentd
   labels:
-    pod-security.kubernetes.io/audit: baseline
-    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce: baseline

--- a/apps/podinfo/namespace.yaml
+++ b/apps/podinfo/namespace.yaml
@@ -3,5 +3,4 @@ kind: Namespace
 metadata:
   name: podinfo
   labels:
-    pod-security.kubernetes.io/audit: baseline
-    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/enforce: baseline

--- a/apps/traefik-blue-variant/namespace.yaml
+++ b/apps/traefik-blue-variant/namespace.yaml
@@ -4,5 +4,4 @@ kind: Namespace
 metadata:
   name: traefik-blue-variant
   labels:
-    pod-security.kubernetes.io/audit: baseline
-    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/enforce: baseline

--- a/apps/traefik-green-variant/namespace.yaml
+++ b/apps/traefik-green-variant/namespace.yaml
@@ -4,5 +4,4 @@ kind: Namespace
 metadata:
   name: traefik-green-variant
   labels:
-    pod-security.kubernetes.io/audit: baseline
-    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/enforce: baseline

--- a/apps/traefik/namespace.yaml
+++ b/apps/traefik/namespace.yaml
@@ -4,5 +4,4 @@ kind: Namespace
 metadata:
   name: traefik
   labels:
-    pod-security.kubernetes.io/audit: baseline
-    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/enforce: baseline

--- a/apps/velero/namespace.yaml
+++ b/apps/velero/namespace.yaml
@@ -4,5 +4,4 @@ kind: Namespace
 metadata:
   name: velero
   labels:
-    pod-security.kubernetes.io/audit: baseline
-    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/enforce: baseline


### PR DESCRIPTION
The namespaces have already been updated. This prevents the change from being reverted.