### PR TITLE
Add goldpinger to Flux

### DIFF
--- a/apps/goldpinger/kustomization.yaml
+++ b/apps/goldpinger/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: monitoring
+namespace: goldpinger
 resources:
+  - namespace.yaml
+  - limitrange.yaml
   - release.yaml
-  

--- a/apps/goldpinger/limitrange.yaml
+++ b/apps/goldpinger/limitrange.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: admission-resources
+  namespace: goldpinger
+spec:
+  limits:
+    - default:
+        cpu: "1"
+        memory: 256Mi
+      defaultRequest:
+        cpu: 20m
+        memory: 64Mi
+      max:
+        cpu: "4"
+        memory: 16Gi
+      type: Container
+    - max:
+        cpu: "4"
+        memory: 16Gi
+      type: Pod

--- a/apps/goldpinger/namespace.yaml
+++ b/apps/goldpinger/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: goldpinger
+  labels:
+    pod-security.kubernetes.io/enforce: baseline

--- a/apps/goldpinger/release.yaml
+++ b/apps/goldpinger/release.yaml
@@ -7,7 +7,7 @@ spec:
   chart:
     spec:
       chart: goldpinger
-      version: 6.2.0
+      version: 1.0.0
       sourceRef:
         kind: HelmRepository
         name: goldpinger

--- a/apps/goldpinger/release.yaml
+++ b/apps/goldpinger/release.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -11,8 +10,26 @@ spec:
       version: 6.2.0
       sourceRef:
         kind: HelmRepository
-        name: helm-stable
+        name: goldpinger
         namespace: flux-system
+  values:
+    priorityClassName: cluster-monitoring
+    serviceMonitor:
+      enabled: true
+      selector:
+        release: monitoring
+    resources:
+      limits:
+        cpu: 100m
+        memory: 512Mi
+      requests:
+        cpu: 10m
+        memory: 50Mi
+    tolerations:
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
   interval: 1m0s
   releaseName: goldpinger
-  targetNamespace: monitoring
+  targetNamespace: goldpinger

--- a/apps/goldpinger/release.yaml
+++ b/apps/goldpinger/release.yaml
@@ -4,6 +4,7 @@ metadata:
   name: goldpinger
   namespace: flux-system
 spec:
+  releaseName: goldpinger
   chart:
     spec:
       chart: goldpinger
@@ -12,6 +13,10 @@ spec:
         kind: HelmRepository
         name: goldpinger
         namespace: flux-system
+  interval: 1m0s
+  install:
+    remediation:
+      retries: 3
   values:
     priorityClassName: cluster-monitoring
     serviceMonitor:
@@ -30,6 +35,3 @@ spec:
         operator: Exists
       - effect: NoSchedule
         operator: Exists
-  interval: 1m0s
-  releaseName: goldpinger
-  targetNamespace: goldpinger

--- a/apps/traefik-blue-variant/release.yaml
+++ b/apps/traefik-blue-variant/release.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: traefik
+      version: 28.3.0
       sourceRef:
         kind: HelmRepository
         name: traefik

--- a/apps/traefik-green-variant/release.yaml
+++ b/apps/traefik-green-variant/release.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: traefik
+      version: 28.3.0
       sourceRef:
         kind: HelmRepository
         name: traefik

--- a/apps/velero/release.yaml
+++ b/apps/velero/release.yaml
@@ -20,7 +20,7 @@ spec:
   values:
     image:
       name: velero/velero
-      tag: v1.12.4
+      tag: v1.13.2
     cleanUpCRDs: true
     credentials:
       useSecret: false

--- a/sources/goldpinger.yaml
+++ b/sources/goldpinger.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: goldpinger
+  namespace: flux-system
+spec:
+  interval: 5m0s
+  url: https://bloomberg.github.io/goldpinger

--- a/sources/kustomization.yaml
+++ b/sources/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - sstarcher.yaml
   - external-secrets.yaml
   - metrics-server.yaml
+  - goldpinger.yaml


### PR DESCRIPTION
This is related to two issues:
- https://github.com/dfds/cloudplatform/issues/2673 
- https://github.com/dfds/cloudplatform/issues/2859

Changes:
- Add goldpinger to Flux, but it needs to be enabled through Terraform/Terragrunt
- Use the new official Helm chart by bloomberg.github.io instead of the deprecated Helm chart by okgolove.github.io
- Add versioning of Traefik Helm chart, that only will be used if not helm chart version is specified in Traefik