### PR TITLE
fix: remove renovate global config options

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "branchPrefix": "feature/renovate/",
-    "repositories": [
-        "dfds/platform-apps"
-    ],
     "flux": {
         "fileMatch": ["\\.yaml$"]
     },


### PR DESCRIPTION
Fixes warnings:

```
WARN: Found renovate config warnings (repository=dfds/platform-apps)
       "warnings": [
         {
           "topic": "Configuration Error",
           "message": "The \"repositories\" option is a global option reserved only for Renovate's global configuration and cannot be configured within a repository's config file."
         }
       ]
```