### PR TITLE
Use GetParametersByPath instead of GetParamater with SSM

### DIFF
--- a/apps/atlantis/externalsecret.yaml
+++ b/apps/atlantis/externalsecret.yaml
@@ -11,181 +11,20 @@ spec:
   target:
     name: atlantis-environment
     creationPolicy: Owner
-  data:
-    - secretKey: CONFLUENT_KAFKA_PROD_PROMETHEUS_METRICS_EXPORTER_HELLMAN_API_KEY
-      remoteRef:
-        key: /atlantis/CONFLUENT_KAFKA_PROD_PROMETHEUS_METRICS_EXPORTER_HELLMAN_API_KEY
-    # trunk-ignore(checkov/CKV_SECRET_6)
-    - secretKey: CONFLUENT_KAFKA_PROD_PROMETHEUS_METRICS_EXPORTER_HELLMAN_API_SECRET
-      remoteRef:
-        key: /atlantis/CONFLUENT_KAFKA_PROD_PROMETHEUS_METRICS_EXPORTER_HELLMAN_API_SECRET
-    - secretKey: PRODUCTION_AWS_ACCESS_KEY_ID
-      remoteRef:
-        key: /atlantis/PRODUCTION_AWS_ACCESS_KEY_ID
-    - secretKey: PRODUCTION_AWS_ACCOUNT_MANIFESTS_HARDENED_MONITORING_SLACK_TOKEN
-      remoteRef:
-        key: /atlantis/PRODUCTION_AWS_ACCOUNT_MANIFESTS_HARDENED_MONITORING_SLACK_TOKEN
-    - secretKey: PRODUCTION_AWS_ACCOUNT_MANIFESTS_KAFKA_BROKER
-      remoteRef:
-        key: /atlantis/PRODUCTION_AWS_ACCOUNT_MANIFESTS_KAFKA_BROKER
-    - secretKey: PRODUCTION_AWS_ACCOUNT_MANIFESTS_KAFKA_PASSWORD
-      remoteRef:
-        key: /atlantis/PRODUCTION_AWS_ACCOUNT_MANIFESTS_KAFKA_PASSWORD
-    - secretKey: PRODUCTION_AWS_ACCOUNT_MANIFESTS_KAFKA_USERNAME
-      remoteRef:
-        key: /atlantis/PRODUCTION_AWS_ACCOUNT_MANIFESTS_KAFKA_USERNAME
-    # trunk-ignore(checkov/CKV_SECRET_6)
-    - secretKey: PRODUCTION_AWS_SECRET_ACCESS_KEY
-      remoteRef:
-        key: /atlantis/PRODUCTION_AWS_SECRET_ACCESS_KEY
-    - secretKey: PRODUCTION_DATALAKE_AWS_ACCESS_KEY_ID
-      remoteRef:
-        key: /atlantis/PRODUCTION_DATALAKE_AWS_ACCESS_KEY_ID
-    # trunk-ignore(checkov/CKV_SECRET_6)
-    - secretKey: PRODUCTION_DATALAKE_AWS_SECRET_ACCESS_KEY
-      remoteRef:
-        key: /atlantis/PRODUCTION_DATALAKE_AWS_SECRET_ACCESS_KEY
-    # trunk-ignore(checkov/CKV_SECRET_6)
-    - secretKey: PRODUCTION_GRAFANA_1PASSWORD_API_KEY
-      remoteRef:
-        key: /atlantis/PRODUCTION_GRAFANA_1PASSWORD_API_KEY
-    - secretKey: PRODUCTION_GRAFANA_AGENT_API_TOKEN
-      remoteRef:
-        key: /atlantis/PRODUCTION_GRAFANA_AGENT_API_TOKEN
-    - secretKey: PRODUCTION_GRAFANA_AGENT_LOKI_URL
-      remoteRef:
-        key: /atlantis/PRODUCTION_GRAFANA_AGENT_LOKI_URL
-    - secretKey: PRODUCTION_GRAFANA_AGENT_LOKI_USERNAME
-      remoteRef:
-        key: /atlantis/PRODUCTION_GRAFANA_AGENT_LOKI_USERNAME
-    - secretKey: PRODUCTION_GRAFANA_AGENT_PROMETHEUS_URL
-      remoteRef:
-        key: /atlantis/PRODUCTION_GRAFANA_AGENT_PROMETHEUS_URL
-    - secretKey: PRODUCTION_GRAFANA_AGENT_PROMETHEUS_USERNAME
-      remoteRef:
-        key: /atlantis/PRODUCTION_GRAFANA_AGENT_PROMETHEUS_USERNAME
-    - secretKey: PRODUCTION_GRAFANA_AGENT_TEMPO_URL
-      remoteRef:
-        key: /atlantis/PRODUCTION_GRAFANA_AGENT_TEMPO_URL
-    - secretKey: PRODUCTION_GRAFANA_AGENT_TEMPO_USERNAME
-      remoteRef:
-        key: /atlantis/PRODUCTION_GRAFANA_AGENT_TEMPO_USERNAME
-    - secretKey: PRODUCTION_GRAFANA_CLOUD_API_KEY
-      remoteRef:
-        key: /atlantis/PRODUCTION_GRAFANA_CLOUD_API_KEY
-    - secretKey: PRODUCTION_GRAFANA_CLOUD_ARM_CLIENT_ID
-      remoteRef:
-        key: /atlantis/PRODUCTION_GRAFANA_CLOUD_ARM_CLIENT_ID
-    # trunk-ignore(checkov/CKV_SECRET_6)
-    - secretKey: PRODUCTION_GRAFANA_CLOUD_ARM_CLIENT_SECRET
-      remoteRef:
-        key: /atlantis/PRODUCTION_GRAFANA_CLOUD_ARM_CLIENT_SECRET
-    - secretKey: PRODUCTION_GRAFANA_CLOUD_ARM_TENANT_ID
-      remoteRef:
-        key: /atlantis/PRODUCTION_GRAFANA_CLOUD_ARM_TENANT_ID
-    - secretKey: PRODUCTION_GRAFANA_CLOUD_SSO_SAML_CERTIFICATE
-      remoteRef:
-        key: /atlantis/PRODUCTION_GRAFANA_CLOUD_SSO_SAML_CERTIFICATE
-    - secretKey: PRODUCTION_GRAFANA_CLOUD_SSO_SAML_IDP_METADATA_URL
-      remoteRef:
-        key: /atlantis/PRODUCTION_GRAFANA_CLOUD_SSO_SAML_IDP_METADATA_URL
-    - secretKey: PRODUCTION_GRAFANA_CLOUD_SSO_SAML_PRIVATE_KEY
-      remoteRef:
-        key: /atlantis/PRODUCTION_GRAFANA_CLOUD_SSO_SAML_PRIVATE_KEY
-    - secretKey: PRODUCTION_GRAFANA_CLOUD_AZURE_SP_ADMIN_CONSENT_CLIENT_ID
-      remoteRef:
-        key: /atlantis/PRODUCTION_GRAFANA_CLOUD_AZURE_SP_ADMIN_CONSENT_CLIENT_ID
-    - secretKey: PRODUCTION_GRAFANA_CLOUD_AZURE_SP_ADMIN_CONSENT_CLIENT_SECRET
-      remoteRef:
-        key: /atlantis/PRODUCTION_GRAFANA_CLOUD_AZURE_SP_ADMIN_CONSENT_CLIENT_SECRET
-    - secretKey: PRODUCTION_PREPRIME_AWS_ACCESS_KEY_ID
-      remoteRef:
-        key: /atlantis/PRODUCTION_PREPRIME_AWS_ACCESS_KEY_ID
-    # trunk-ignore(checkov/CKV_SECRET_6)
-    - secretKey: PRODUCTION_PREPRIME_AWS_SECRET_ACCESS_KEY
-      remoteRef:
-        key: /atlantis/PRODUCTION_PREPRIME_AWS_SECRET_ACCESS_KEY
-    - secretKey: PRODUCTION_PREPRIME_BACKUP_REPORTS_SLACK_WEBHOOK_URL
-      remoteRef:
-        key: /atlantis/PRODUCTION_PREPRIME_BACKUP_REPORTS_SLACK_WEBHOOK_URL
-    - secretKey: PRODUCTION_PRIME_AWS_ACCESS_KEY_ID
-      remoteRef:
-        key: /atlantis/PRODUCTION_PRIME_AWS_ACCESS_KEY_ID
-    # trunk-ignore(checkov/CKV_SECRET_6)
-    - secretKey: PRODUCTION_PRIME_AWS_SECRET_ACCESS_KEY
-      remoteRef:
-        key: /atlantis/PRODUCTION_PRIME_AWS_SECRET_ACCESS_KEY
-    - secretKey: PRODUCTION_TF_VAR_monitoring_kube_prometheus_stack_slack_webhook
-      remoteRef:
-        key: /atlantis/PRODUCTION_TF_VAR_monitoring_kube_prometheus_stack_slack_webhook
-    - secretKey: PRODUCTION_TF_VAR_slack_webhook_url
-      remoteRef:
-        key: /atlantis/PRODUCTION_TF_VAR_slack_webhook_url
-    - secretKey: SHARED_ARM_CLIENT_ID
-      remoteRef:
-        key: /atlantis/SHARED_ARM_CLIENT_ID
-    # trunk-ignore(checkov/CKV_SECRET_6)
-    - secretKey: SHARED_ARM_CLIENT_SECRET
-      remoteRef:
-        key: /atlantis/SHARED_ARM_CLIENT_SECRET
-    - secretKey: SHARED_ARM_SUBSCRIPTION_ID
-      remoteRef:
-        key: /atlantis/SHARED_ARM_SUBSCRIPTION_ID
-    - secretKey: SHARED_ARM_TENANT_ID
-      remoteRef:
-        key: /atlantis/SHARED_ARM_TENANT_ID
-    - secretKey: SHARED_TF_VAR_atlantis_github_token
-      remoteRef:
-        key: /atlantis/SHARED_TF_VAR_atlantis_github_token
-    - secretKey: SHARED_TF_VAR_fluxcd_bootstrap_repo_owner_token
-      remoteRef:
-        key: /atlantis/SHARED_TF_VAR_fluxcd_bootstrap_repo_owner_token
-    - secretKey: SHARED_TF_VAR_monitoring_kube_prometheus_stack_azure_tenant_id
-      remoteRef:
-        key: /atlantis/SHARED_TF_VAR_monitoring_kube_prometheus_stack_azure_tenant_id
-    - secretKey: STAGING_AWS_ACCESS_KEY_ID
-      remoteRef:
-        key: /atlantis/STAGING_AWS_ACCESS_KEY_ID
-    # trunk-ignore(checkov/CKV_SECRET_6)
-    - secretKey: STAGING_AWS_SECRET_ACCESS_KEY
-      remoteRef:
-        key: /atlantis/STAGING_AWS_SECRET_ACCESS_KEY
-    - secretKey: STAGING_GRAFANA_AGENT_API_TOKEN
-      remoteRef:
-        key: /atlantis/STAGING_GRAFANA_AGENT_API_TOKEN
-    - secretKey: STAGING_GRAFANA_AGENT_LOKI_URL
-      remoteRef:
-        key: /atlantis/STAGING_GRAFANA_AGENT_LOKI_URL
-    - secretKey: STAGING_GRAFANA_AGENT_LOKI_USERNAME
-      remoteRef:
-        key: /atlantis/STAGING_GRAFANA_AGENT_LOKI_USERNAME
-    - secretKey: STAGING_GRAFANA_AGENT_PROMETHEUS_URL
-      remoteRef:
-        key: /atlantis/STAGING_GRAFANA_AGENT_PROMETHEUS_URL
-    - secretKey: STAGING_GRAFANA_AGENT_PROMETHEUS_USERNAME
-      remoteRef:
-        key: /atlantis/STAGING_GRAFANA_AGENT_PROMETHEUS_USERNAME
-    - secretKey: STAGING_GRAFANA_AGENT_TEMPO_URL
-      remoteRef:
-        key: /atlantis/STAGING_GRAFANA_AGENT_TEMPO_URL
-    - secretKey: STAGING_GRAFANA_AGENT_TEMPO_USERNAME
-      remoteRef:
-        key: /atlantis/STAGING_GRAFANA_AGENT_TEMPO_USERNAME
-    - secretKey: STAGING_TF_VAR_monitoring_kube_prometheus_stack_slack_webhook
-      remoteRef:
-        key: /atlantis/STAGING_TF_VAR_monitoring_kube_prometheus_stack_slack_webhook
-    - secretKey: STAGING_TF_VAR_slack_webhook_url
-      remoteRef:
-        key: /atlantis/STAGING_TF_VAR_slack_webhook_url
-    - secretKey: STAGING_TF_VAR_falco_slack_alert_webhook_url
-      remoteRef:
-        key: /falco/STAGING_TF_VAR_falco_slack_alert_webhook_url
-    - secretKey: STAGING_TF_VAR_falco_stream_webhook_url
-      remoteRef:
-        key: /falco/STAGING_TF_VAR_falco_stream_webhook_url
-    - secretKey: PRODUCTION_TF_VAR_falco_slack_alert_webhook_url
-      remoteRef:
-        key: /falco/PRODUCTION_TF_VAR_falco_slack_alert_webhook_url
-    - secretKey: PRODUCTION_TF_VAR_falco_stream_webhook_url
-      remoteRef:
-        key: /falco/PRODUCTION_TF_VAR_falco_stream_webhook_url
+  dataFrom:
+    - find:
+        path: /atlantis
+        name:
+          regexp: .*
+      rewrite:
+        - regexp:
+            source: "/atlantis/(.*)"
+            target: "${1}"
+    - find:
+        path: /falco
+        name:
+          regexp: .*
+      rewrite:
+      - regexp:
+          source: "/falco/(.*)"
+          target: "${1}"

--- a/apps/atlantis/externalsecret.yaml
+++ b/apps/atlantis/externalsecret.yaml
@@ -4,7 +4,7 @@ metadata:
   name: atlantis
   namespace: atlantis
 spec:
-  refreshInterval: 1m
+  refreshInterval: 1h
   secretStoreRef:
     kind: SecretStore
     name: atlantis-ssm


### PR DESCRIPTION
Using GetParametersByPath instead of GetParamater with SSM means fewer API calls.