### PR TITLE
scarpe metrics for traefik custom resources

### DIFF
--- a/apps/grafana/release.yaml
+++ b/apps/grafana/release.yaml
@@ -73,6 +73,7 @@ spec:
         metricsTuning:
           useDefaultAllowList: false
         rbac:
+          create: true
           extraRules:
             - apiGroups: ["traefik.contanio.io", "traefik.io"]
               resources: ["ingressroutes"]

--- a/apps/grafana/release.yaml
+++ b/apps/grafana/release.yaml
@@ -74,14 +74,8 @@ spec:
           useDefaultAllowList: false
         rbac:
           extraRules:
-            # - apiGroups: ["kustomize.toolkit.fluxcd.io", "source.toolkit.fluxcd.io"]
-            #   resources: ["gitrepositories", "kustomizations"]
-            #   verbs: ["list", "watch"]
-            - apiGroups:
-                - traefik.contanio.io
-                - traefik.io
-              resources:
-                - ingressroutes
+            - apiGroups: ["traefik.contanio.io", "traefik.io"]
+              resources: ["ingressroutes"]
               verbs: [ "list", "watch" ]
         customResourceState:
           enabled: true

--- a/apps/grafana/release.yaml
+++ b/apps/grafana/release.yaml
@@ -112,7 +112,7 @@ spec:
                   - name: "resource_info"
                     help: "The current state of Traefik migration from old traefik ingressroute."
                     each:
-                      type: Counter
+                      type: Info
                       # gauge:
                       #   path: [metadata, name]
               - groupVersionKind:
@@ -124,7 +124,7 @@ spec:
                   - name: "resource_info"
                     help: "The current state of Traefik migration to new traefik ingressroute."
                     each:
-                      type: Counter
+                      type: Info
                       # gauge:
                       #   path: [metadata, name]
                     # each:

--- a/apps/grafana/release.yaml
+++ b/apps/grafana/release.yaml
@@ -112,7 +112,7 @@ spec:
                   - name: "resource_info"
                     help: "The current state of Traefik migration from old traefik ingressroute."
                     each:
-                      type: Gauge
+                      type: Counter
                       # gauge:
                       #   path: [metadata, name]
               - groupVersionKind:
@@ -124,7 +124,7 @@ spec:
                   - name: "resource_info"
                     help: "The current state of Traefik migration to new traefik ingressroute."
                     each:
-                      type: Gauge
+                      type: Counter
                       # gauge:
                       #   path: [metadata, name]
                     # each:

--- a/apps/grafana/release.yaml
+++ b/apps/grafana/release.yaml
@@ -95,7 +95,7 @@ spec:
       rbac:
         create: true
         extraRules:
-          - apiGroups: ["traefik.contanio.io", "traefik.io"]
+          - apiGroups: ["traefik.containo.us", "traefik.io"]
             resources: ["ingressroutes"]
             verbs: [ "list", "watch" ]
       customResourceState:
@@ -104,7 +104,7 @@ spec:
           spec:
             resources:
               - groupVersionKind:
-                  group: traefik.contanio.io
+                  group: traefik.containo.us
                   version: v1alpha1
                   kind: IngressRoute
                 metricNamePrefix: traefik_ingressroute_old

--- a/apps/grafana/release.yaml
+++ b/apps/grafana/release.yaml
@@ -113,8 +113,8 @@ spec:
                     help: "The current state of Traefik migration from old traefik ingressroute."
                     each:
                       type: Gauge
-                      gauge:
-                        path: [metadata, name]
+                      # gauge:
+                      #   path: [metadata, name]
               - groupVersionKind:
                   group: traefik.io
                   version: v1alpha1
@@ -125,8 +125,8 @@ spec:
                     help: "The current state of Traefik migration to new traefik ingressroute."
                     each:
                       type: Gauge
-                      gauge:
-                        path: [metadata, name]
+                      # gauge:
+                      #   path: [metadata, name]
                     # each:
                     #   type: Info
                     #   info:

--- a/apps/grafana/release.yaml
+++ b/apps/grafana/release.yaml
@@ -74,6 +74,41 @@ spec:
           useDefaultAllowList: false
         customResourceState:
           enabled: true
+          config:
+            spec:
+              resources:
+                - groupVersionKind:
+                    group: traefik.contanio.io
+                    version: v1alpha1
+                    kind: IngressRoute
+                  metricNamePrefix: traefik_ingressroute
+                  metrics:
+                    - name: "resource_info"
+                      help: "The current state of Traefik migration."
+                      each:
+                        type: Gauge
+                        gauge:
+                          path: [metadata, annotations]
+                      # each:
+                      #   type: Info
+                      #   info:
+                      #     labelsFromPath:
+                      #       name: [ metadata, name ]
+                      # labelsFromPath:
+                      #   exported_namespace: [ metadata, namespace ]
+                      #   ready: [ status, conditions, "[type=Ready]", status ]
+                      #   suspended: [ spec, suspend ]
+                      #   revision: [ status, lastAppliedRevision ]
+                      #   source_name: [ spec, sourceRef, name ]
+        # - groupVersionKind:
+        #     group: myteam.io
+        #     kind: "Foo"
+        #     version: "v1"
+        #   metrics:
+        #     - name: "uptime"
+        #       help: "Foo uptime"
+        #       each:
+        #         path: [status, uptime]
       cadvisor:
         metricsTuning:
           useDefaultAllowList: false

--- a/apps/grafana/release.yaml
+++ b/apps/grafana/release.yaml
@@ -103,18 +103,18 @@ spec:
         config:
           spec:
             resources:
-              - groupVersionKind:
-                  group: traefik.containo.us
-                  version: v1alpha1
-                  kind: IngressRoute
-                metricNamePrefix: traefik_ingressroute_old
-                metrics:
-                  - name: "resource_info"
-                    help: "The current state of Traefik migration from old traefik ingressroute."
-                    each:
-                      type: Info
-                      # gauge:
-                      #   path: [metadata, name]
+              # - groupVersionKind:
+              #     group: traefik.containo.us
+              #     version: v1alpha1
+              #     kind: IngressRoute
+              #   metricNamePrefix: traefik_ingressroute_old
+              #   metrics:
+              #     - name: "resource_info"
+              #       help: "The current state of Traefik migration from old traefik ingressroute."
+              #       each:
+              #         type: Info
+              #         # gauge:
+              #         #   path: [metadata, name]
               - groupVersionKind:
                   group: traefik.io
                   version: v1alpha1
@@ -127,7 +127,10 @@ spec:
                       type: Gauge
                       gauge:
                         # path: [status, active]
-                        labelFromKey: type
+                        # labelFromKey: type
+                        path:
+                        - metadata
+                        - creationTimestamp
                         # labelsFromPath:
                         #   bar: [bar]
                         value: [count]

--- a/apps/grafana/release.yaml
+++ b/apps/grafana/release.yaml
@@ -114,7 +114,7 @@ spec:
                     each:
                       type: Gauge
                       gauge:
-                        path: [metadata, annotations]
+                        path: [metadata, apiVersion]
               - groupVersionKind:
                   group: traefik.io
                   version: v1alpha1
@@ -126,7 +126,7 @@ spec:
                     each:
                       type: Gauge
                       gauge:
-                        path: [metadata, annotations]
+                        path: [metadata, apiVersion]
                     # each:
                     #   type: Info
                     #   info:

--- a/apps/grafana/release.yaml
+++ b/apps/grafana/release.yaml
@@ -110,7 +110,7 @@ spec:
                 # metricNamePrefix: traefik_custom # can be omitted. Default is kube_customresource
                 metrics:
                   - name: "traefik" #"ingressroute"
-                    help: "The current state of Traefik ingressroutes migration to V3."
+                    help: 'Monitor Traefik ingressroute resources that make use of "traefik.io" API group.'
                     each:
                       type: Info
                       info:
@@ -120,37 +120,41 @@ spec:
                   group: traefik.io
                   version: v1alpha1
                   kind: Middleware
-                metricNamePrefix: traefik_custom
+                # metricNamePrefix: traefik_custom
                 metrics:
                   - name: "traefik" #"middleware"
-                    help: "The current state of Traefik middlewares migration to V3."
+                    help: 'Monitor Traefik middleware resources that make use of "traefik.io" API group.'
                     each:
                       type: Info
                       info:
                         labelsFromPath:
                           name: [ metadata, name ]
-                      # gauge:
-                      #   path: [metadata, name]
-                    # each:
-                    #   type: Info
-                    #   info:
-                    #     labelsFromPath:
-                    #       name: [ metadata, name ]
-                    # labelsFromPath:
-                    #   exported_namespace: [ metadata, namespace ]
-                    #   ready: [ status, conditions, "[type=Ready]", status ]
-                    #   suspended: [ spec, suspend ]
-                    #   revision: [ status, lastAppliedRevision ]
-                    #   source_name: [ spec, sourceRef, name ]
-      # - groupVersionKind:
-      #     group: myteam.io
-      #     kind: "Foo"
-      #     version: "v1"
-      #   metrics:
-      #     - name: "uptime"
-      #       help: "Foo uptime"
-      #       each:
-      #         path: [status, uptime]
+              - groupVersionKind:
+                  group: traefik.containo.us
+                  version: v1alpha1
+                  kind: IngressRoute
+                # metricNamePrefix: traefik_custom # can be omitted. Default is kube_customresource
+                metrics:
+                  - name: "traefik" #"ingressroute"
+                    help: 'Monitor Traefik ingressroute resources that make use of "traefik.containo.us" API group.'
+                    each:
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          name: [ metadata, name ]
+              - groupVersionKind:
+                  group: traefik.containo.us
+                  version: v1alpha1
+                  kind: Middleware
+                # metricNamePrefix: traefik_custom
+                metrics:
+                  - name: "traefik" #"middleware"
+                    help: 'Monitor Traefik middleware resources that make use of "traefik.containo.us" old API group.'
+                    each:
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          name: [ metadata, name ]
     prometheus-node-exporter:
       enabled: true
       podLabels:

--- a/apps/grafana/release.yaml
+++ b/apps/grafana/release.yaml
@@ -124,17 +124,15 @@ spec:
                   - name: "resource_info"
                     help: "The current state of Traefik migration to new traefik ingressroute."
                     each:
-                      type: Gauge
-                      gauge:
-                        # path: [status, active]
-                        # labelFromKey: type
-                        path:
-                        - metadata
-                        - creationTimestamp
-                        # labelsFromPath:
-                        #   bar: [bar]
-                        value: [count]
-                    #   type: Info
+                      # type: Gauge
+                      # gauge:
+                      #   path:
+                      #   - metadata
+                      #   value: [count]
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          name: [ metadata, name ]
                       # gauge:
                       #   path: [metadata, name]
                     # each:

--- a/apps/grafana/release.yaml
+++ b/apps/grafana/release.yaml
@@ -124,7 +124,14 @@ spec:
                   - name: "resource_info"
                     help: "The current state of Traefik migration to new traefik ingressroute."
                     each:
-                      type: Info
+                      type: Gauge
+                      gauge:
+                        # path: [status, active]
+                        labelFromKey: type
+                        # labelsFromPath:
+                        #   bar: [bar]
+                        value: [count]
+                    #   type: Info
                       # gauge:
                       #   path: [metadata, name]
                     # each:

--- a/apps/grafana/release.yaml
+++ b/apps/grafana/release.yaml
@@ -96,39 +96,35 @@ spec:
         create: true
         extraRules:
           - apiGroups: ["traefik.containo.us", "traefik.io"]
-            resources: ["ingressroutes"]
+            resources: ["ingressroutes", "middlewares"]
             verbs: [ "list", "watch" ]
       customResourceState:
         enabled: true
         config:
           spec:
             resources:
-              # - groupVersionKind:
-              #     group: traefik.containo.us
-              #     version: v1alpha1
-              #     kind: IngressRoute
-              #   metricNamePrefix: traefik_ingressroute_old
-              #   metrics:
-              #     - name: "resource_info"
-              #       help: "The current state of Traefik migration from old traefik ingressroute."
-              #       each:
-              #         type: Info
-              #         # gauge:
-              #         #   path: [metadata, name]
               - groupVersionKind:
                   group: traefik.io
                   version: v1alpha1
                   kind: IngressRoute
-                metricNamePrefix: traefik_ingressroute_new
+                metricNamePrefix: traefik_custom
                 metrics:
-                  - name: "resource_info"
-                    help: "The current state of Traefik migration to new traefik ingressroute."
+                  - name: "ingressroute"
+                    help: "The current state of Traefik ingressroutes migration to V3."
                     each:
-                      # type: Gauge
-                      # gauge:
-                      #   path:
-                      #   - metadata
-                      #   value: [count]
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          name: [ metadata, name ]
+              - groupVersionKind:
+                  group: traefik.io
+                  version: v1alpha1
+                  kind: Middleware
+                metricNamePrefix: traefik_custom
+                metrics:
+                  - name: "middleware"
+                    help: "The current state of Traefik middlewares migration to V3."
+                    each:
                       type: Info
                       info:
                         labelsFromPath:

--- a/apps/grafana/release.yaml
+++ b/apps/grafana/release.yaml
@@ -114,7 +114,7 @@ spec:
                     each:
                       type: Gauge
                       gauge:
-                        path: [metadata]
+                        path: [metadata, name]
               - groupVersionKind:
                   group: traefik.io
                   version: v1alpha1
@@ -126,7 +126,7 @@ spec:
                     each:
                       type: Gauge
                       gauge:
-                        path: [metadata]
+                        path: [metadata, name]
                     # each:
                     #   type: Info
                     #   info:

--- a/apps/grafana/release.yaml
+++ b/apps/grafana/release.yaml
@@ -72,6 +72,8 @@ spec:
       kube-state-metrics:
         metricsTuning:
           useDefaultAllowList: false
+        customResourceState:
+          enabled: true
       cadvisor:
         metricsTuning:
           useDefaultAllowList: false

--- a/apps/grafana/release.yaml
+++ b/apps/grafana/release.yaml
@@ -72,6 +72,17 @@ spec:
       kube-state-metrics:
         metricsTuning:
           useDefaultAllowList: false
+        rbac:
+          extraRules:
+            # - apiGroups: ["kustomize.toolkit.fluxcd.io", "source.toolkit.fluxcd.io"]
+            #   resources: ["gitrepositories", "kustomizations"]
+            #   verbs: ["list", "watch"]
+            - apiGroups:
+                - traefik.contanio.io
+                - traefik.io
+              resources:
+                - ingressroutes
+              verbs: [ "list", "watch" ]
         customResourceState:
           enabled: true
           config:
@@ -81,10 +92,22 @@ spec:
                     group: traefik.contanio.io
                     version: v1alpha1
                     kind: IngressRoute
-                  metricNamePrefix: traefik_ingressroute
+                  metricNamePrefix: traefik_ingressroute_old
                   metrics:
                     - name: "resource_info"
-                      help: "The current state of Traefik migration."
+                      help: "The current state of Traefik migration from old traefik ingressroute."
+                      each:
+                        type: Gauge
+                        gauge:
+                          path: [metadata, annotations]
+                - groupVersionKind:
+                    group: traefik.io
+                    version: v1alpha1
+                    kind: IngressRoute
+                  metricNamePrefix: traefik_ingressroute_new
+                  metrics:
+                    - name: "resource_info"
+                      help: "The current state of Traefik migration to new traefik ingressroute."
                       each:
                         type: Gauge
                         gauge:

--- a/apps/grafana/release.yaml
+++ b/apps/grafana/release.yaml
@@ -116,6 +116,7 @@ spec:
                       info:
                         labelsFromPath:
                           name: [ metadata, name ]
+                          namespace: [ metadata, namespace ]
               - groupVersionKind:
                   group: traefik.io
                   version: v1alpha1
@@ -129,6 +130,7 @@ spec:
                       info:
                         labelsFromPath:
                           name: [ metadata, name ]
+                          namespace: [ metadata, namespace ]
               - groupVersionKind:
                   group: traefik.containo.us
                   version: v1alpha1
@@ -142,6 +144,7 @@ spec:
                       info:
                         labelsFromPath:
                           name: [ metadata, name ]
+                          namespace: [ metadata, namespace ]
               - groupVersionKind:
                   group: traefik.containo.us
                   version: v1alpha1
@@ -155,6 +158,7 @@ spec:
                       info:
                         labelsFromPath:
                           name: [ metadata, name ]
+                          namespace: [ metadata, namespace ]
     prometheus-node-exporter:
       enabled: true
       podLabels:

--- a/apps/grafana/release.yaml
+++ b/apps/grafana/release.yaml
@@ -107,9 +107,8 @@ spec:
                   group: traefik.io
                   version: v1alpha1
                   kind: IngressRoute
-                # metricNamePrefix: traefik_custom # can be omitted. Default is kube_customresource
                 metrics:
-                  - name: "traefik" #"ingressroute"
+                  - name: "traefik"
                     help: 'Monitor Traefik ingressroute resources that make use of "traefik.io" API group.'
                     each:
                       type: Info
@@ -121,9 +120,8 @@ spec:
                   group: traefik.io
                   version: v1alpha1
                   kind: Middleware
-                # metricNamePrefix: traefik_custom
                 metrics:
-                  - name: "traefik" #"middleware"
+                  - name: "traefik"
                     help: 'Monitor Traefik middleware resources that make use of "traefik.io" API group.'
                     each:
                       type: Info
@@ -135,9 +133,8 @@ spec:
                   group: traefik.containo.us
                   version: v1alpha1
                   kind: IngressRoute
-                # metricNamePrefix: traefik_custom # can be omitted. Default is kube_customresource
                 metrics:
-                  - name: "traefik" #"ingressroute"
+                  - name: "traefik"
                     help: 'Monitor Traefik ingressroute resources that make use of "traefik.containo.us" API group.'
                     each:
                       type: Info
@@ -149,9 +146,8 @@ spec:
                   group: traefik.containo.us
                   version: v1alpha1
                   kind: Middleware
-                # metricNamePrefix: traefik_custom
                 metrics:
-                  - name: "traefik" #"middleware"
+                  - name: "traefik"
                     help: 'Monitor Traefik middleware resources that make use of "traefik.containo.us" old API group.'
                     each:
                       type: Info

--- a/apps/grafana/release.yaml
+++ b/apps/grafana/release.yaml
@@ -114,7 +114,7 @@ spec:
                     each:
                       type: Gauge
                       gauge:
-                        path: [metadata, apiVersion]
+                        path: [metadata]
               - groupVersionKind:
                   group: traefik.io
                   version: v1alpha1
@@ -126,7 +126,7 @@ spec:
                     each:
                       type: Gauge
                       gauge:
-                        path: [metadata, apiVersion]
+                        path: [metadata]
                     # each:
                     #   type: Info
                     #   info:

--- a/apps/grafana/release.yaml
+++ b/apps/grafana/release.yaml
@@ -107,9 +107,9 @@ spec:
                   group: traefik.io
                   version: v1alpha1
                   kind: IngressRoute
-                metricNamePrefix: traefik_custom
+                # metricNamePrefix: traefik_custom # can be omitted. Default is kube_customresource
                 metrics:
-                  - name: "ingressroute"
+                  - name: "traefik" #"ingressroute"
                     help: "The current state of Traefik ingressroutes migration to V3."
                     each:
                       type: Info
@@ -122,7 +122,7 @@ spec:
                   kind: Middleware
                 metricNamePrefix: traefik_custom
                 metrics:
-                  - name: "middleware"
+                  - name: "traefik" #"middleware"
                     help: "The current state of Traefik middlewares migration to V3."
                     each:
                       type: Info

--- a/apps/grafana/release.yaml
+++ b/apps/grafana/release.yaml
@@ -72,61 +72,6 @@ spec:
       kube-state-metrics:
         metricsTuning:
           useDefaultAllowList: false
-        rbac:
-          create: true
-          extraRules:
-            - apiGroups: ["traefik.contanio.io", "traefik.io"]
-              resources: ["ingressroutes"]
-              verbs: [ "list", "watch" ]
-        customResourceState:
-          enabled: true
-          config:
-            spec:
-              resources:
-                - groupVersionKind:
-                    group: traefik.contanio.io
-                    version: v1alpha1
-                    kind: IngressRoute
-                  metricNamePrefix: traefik_ingressroute_old
-                  metrics:
-                    - name: "resource_info"
-                      help: "The current state of Traefik migration from old traefik ingressroute."
-                      each:
-                        type: Gauge
-                        gauge:
-                          path: [metadata, annotations]
-                - groupVersionKind:
-                    group: traefik.io
-                    version: v1alpha1
-                    kind: IngressRoute
-                  metricNamePrefix: traefik_ingressroute_new
-                  metrics:
-                    - name: "resource_info"
-                      help: "The current state of Traefik migration to new traefik ingressroute."
-                      each:
-                        type: Gauge
-                        gauge:
-                          path: [metadata, annotations]
-                      # each:
-                      #   type: Info
-                      #   info:
-                      #     labelsFromPath:
-                      #       name: [ metadata, name ]
-                      # labelsFromPath:
-                      #   exported_namespace: [ metadata, namespace ]
-                      #   ready: [ status, conditions, "[type=Ready]", status ]
-                      #   suspended: [ spec, suspend ]
-                      #   revision: [ status, lastAppliedRevision ]
-                      #   source_name: [ spec, sourceRef, name ]
-        # - groupVersionKind:
-        #     group: myteam.io
-        #     kind: "Foo"
-        #     version: "v1"
-        #   metrics:
-        #     - name: "uptime"
-        #       help: "Foo uptime"
-        #       each:
-        #         path: [status, uptime]
       cadvisor:
         metricsTuning:
           useDefaultAllowList: false
@@ -147,6 +92,61 @@ spec:
           # additionalLabels: {
           #   release: monitoring
           # }
+      rbac:
+        create: true
+        extraRules:
+          - apiGroups: ["traefik.contanio.io", "traefik.io"]
+            resources: ["ingressroutes"]
+            verbs: [ "list", "watch" ]
+      customResourceState:
+        enabled: true
+        config:
+          spec:
+            resources:
+              - groupVersionKind:
+                  group: traefik.contanio.io
+                  version: v1alpha1
+                  kind: IngressRoute
+                metricNamePrefix: traefik_ingressroute_old
+                metrics:
+                  - name: "resource_info"
+                    help: "The current state of Traefik migration from old traefik ingressroute."
+                    each:
+                      type: Gauge
+                      gauge:
+                        path: [metadata, annotations]
+              - groupVersionKind:
+                  group: traefik.io
+                  version: v1alpha1
+                  kind: IngressRoute
+                metricNamePrefix: traefik_ingressroute_new
+                metrics:
+                  - name: "resource_info"
+                    help: "The current state of Traefik migration to new traefik ingressroute."
+                    each:
+                      type: Gauge
+                      gauge:
+                        path: [metadata, annotations]
+                    # each:
+                    #   type: Info
+                    #   info:
+                    #     labelsFromPath:
+                    #       name: [ metadata, name ]
+                    # labelsFromPath:
+                    #   exported_namespace: [ metadata, namespace ]
+                    #   ready: [ status, conditions, "[type=Ready]", status ]
+                    #   suspended: [ spec, suspend ]
+                    #   revision: [ status, lastAppliedRevision ]
+                    #   source_name: [ spec, sourceRef, name ]
+      # - groupVersionKind:
+      #     group: myteam.io
+      #     kind: "Foo"
+      #     version: "v1"
+      #   metrics:
+      #     - name: "uptime"
+      #       help: "Foo uptime"
+      #       each:
+      #         path: [status, uptime]
     prometheus-node-exporter:
       enabled: true
       podLabels:


### PR DESCRIPTION
This PR configure Kube-State-Metrics po to generate custom timeserieses for Traefik Custom resources to monitor state of switching resources from API group "traefik.containo.us" to "traefik.io"
issue https://github.com/dfds/cloudplatform/issues/2791 