### PR TITLE
allow velero nodeagent to access pod file path on nodes

### DIFF
--- a/apps/velero/namespace.yaml
+++ b/apps/velero/namespace.yaml
@@ -4,4 +4,4 @@ kind: Namespace
 metadata:
   name: velero
   labels:
-    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce: privileged


### PR DESCRIPTION
Enable running NodeAgent pods to run in privileged mode to access file path on host nodes
https://github.com/dfds/cloudplatform/issues/3167