### PR TITLE
Use v1 of apiVersion for ESO

### DIFF
--- a/apps/1password-connect/externalsecret.yaml
+++ b/apps/1password-connect/externalsecret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: 1password-connect

--- a/apps/1password-connect/secretstore.yaml
+++ b/apps/1password-connect/secretstore.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: 1password-connect-ssm

--- a/apps/atlantis/externalsecret.yaml
+++ b/apps/atlantis/externalsecret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: 1password-connect-token
@@ -16,7 +16,7 @@ spec:
       remoteRef:
         key: /atlantis/1password-connect-token
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: atlantis-1password

--- a/apps/atlantis/secretstore.yaml
+++ b/apps/atlantis/secretstore.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: atlantis-ssm
@@ -13,7 +13,7 @@ spec:
           serviceAccountRef:
             name: atlantis
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: atlantis-1password
@@ -29,4 +29,3 @@ spec:
           connectTokenSecretRef:
             name: atlantis-1password-token
             key: token
----


### PR DESCRIPTION
This pull request updates the API version for `ExternalSecret` and `SecretStore` resources across multiple files to align with the latest version of the `external-secrets.io` API. Additionally, it includes updates to the specifications of some `SecretStore` and `ExternalSecret` resources.

### API version updates:
* Updated `apiVersion` from `external-secrets.io/v1beta1` to `external-secrets.io/v1` in `apps/1password-connect/externalsecret.yaml` and `apps/1password-connect/secretstore.yaml`. [[1]](diffhunk://#diff-bf3ec378c242c1283c1e7534a09861fc0430bd054cb21a8149114272b2be844fL1-R1) [[2]](diffhunk://#diff-c0ceffa34280a48c56cff431607283e8a8f3aa3f6b5767af6faa947dee0ae973L1-R1)
* Updated `apiVersion` from `external-secrets.io/v1beta1` to `external-secrets.io/v1` in `apps/atlantis/externalsecret.yaml` and `apps/atlantis/secretstore.yaml`. [[1]](diffhunk://#diff-bf58e0431f4d528b04dd1555e727ee7c8b115548ea1ea1e2578deae42209c60fL1-R1) [[2]](diffhunk://#diff-bf58e0431f4d528b04dd1555e727ee7c8b115548ea1ea1e2578deae42209c60fL19-R19) [[3]](diffhunk://#diff-e8e0d24e92e6af38df6f07cad964a6f4ce4c96f7d7ef39a0e8694f2756f0110aL1-R1) [[4]](diffhunk://#diff-e8e0d24e92e6af38df6f07cad964a6f4ce4c96f7d7ef39a0e8694f2756f0110aL16-R16) [[5]](diffhunk://#diff-e8e0d24e92e6af38df6f07cad964a6f4ce4c96f7d7ef39a0e8694f2756f0110aL32)

### Specification updates:
* Updated `spec:` in `apps/atlantis/externalsecret.yaml` to include a `remoteRef` with the key `/atlantis/1password-connect-token`.
* Updated `spec:` in `apps/atlantis/secretstore.yaml` to include a `serviceAccountRef` for the `atlantis` service account and a `connectTokenSecretRef` for the `atlantis-1password-token`. [[1]](diffhunk://#diff-e8e0d24e92e6af38df6f07cad964a6f4ce4c96f7d7ef39a0e8694f2756f0110aL16-R16) [[2]](diffhunk://#diff-e8e0d24e92e6af38df6f07cad964a6f4ce4c96f7d7ef39a0e8694f2756f0110aL32)