### PR TITLE
Add atlantis var mapping for shared kms key

### DIFF
--- a/apps/atlantis/release.yaml
+++ b/apps/atlantis/release.yaml
@@ -250,6 +250,10 @@ spec:
         secretKeyRef:
           key: SHARED_docker_hub_password
           name: atlantis-environment
+      - name: SHARED_eks_addon_awsebscsidriver_kms_arn
+        secretKeyRef:
+          key: SHARED_eks_addon_awsebscsidriver_kms_arn
+          name: atlantis-environment          
     extraArgs:
       - --parallel-pool-size=15
     github: {} # Patch this from Terraform


### PR DESCRIPTION
This pull request adds a new environment variable to the `apps/atlantis/release.yaml` file. The change introduces a reference to a secret key for the `SHARED_eks_addon_awsebscsidriver_kms_arn` configuration.

### Key change:
* Added a new environment variable `SHARED_eks_addon_awsebscsidriver_kms_arn` with its `secretKeyRef` pointing to the `atlantis-environment` secret.