### PR TITLE
atlantis secret ref to shared kms arn

### DIFF
--- a/apps/atlantis/externalsecret.yaml
+++ b/apps/atlantis/externalsecret.yaml
@@ -258,3 +258,7 @@ spec:
       remoteRef:
         key: Docker Cloud
         property: password
+    - secretKey: SHARED_eks_addon_awsebscsidriver_kms_arn
+      remoteRef:
+        key: Hardened Account EBS Volume Shared KMS Key
+        property: arn        


### PR DESCRIPTION
This pull request adds a new secret configuration to the `apps/atlantis/externalsecret.yaml` file. The change introduces a mapping for the `SHARED_eks_addon_awsebscsidriver_kms_arn` secret key.

* **Secret configuration update**:
  * [`apps/atlantis/externalsecret.yaml`](diffhunk://#diff-bf58e0431f4d528b04dd1555e727ee7c8b115548ea1ea1e2578deae42209c60fR261-R264): Added a new secret key `SHARED_eks_addon_awsebscsidriver_kms_arn` with a remote reference to the "Hardened Account EBS Volume Shared KMS Key" and its `arn` property.