### PR TITLE
chore(secrets): add shared docker hub token to environment secrets

### DIFF
--- a/apps/atlantis/externalsecret.yaml
+++ b/apps/atlantis/externalsecret.yaml
@@ -258,7 +258,11 @@ spec:
       remoteRef:
         key: Docker Cloud
         property: password
+    - secretKey: SHARED_docker_hub_token
+      remoteRef:
+        key: Docker Cloud
+        property: Github Actions Token
     - secretKey: SHARED_eks_addon_awsebscsidriver_kms_arn
       remoteRef:
         key: Hardened Account EBS Volume Shared KMS Key
-        property: arn        
+        property: arn

--- a/apps/atlantis/release.yaml
+++ b/apps/atlantis/release.yaml
@@ -250,10 +250,14 @@ spec:
         secretKeyRef:
           key: SHARED_docker_hub_password
           name: atlantis-environment
+      - name: SHARED_docker_hub_token
+        secretKeyRef:
+          key: SHARED_docker_hub_token
+          name: atlantis-environment
       - name: SHARED_eks_addon_awsebscsidriver_kms_arn
         secretKeyRef:
           key: SHARED_eks_addon_awsebscsidriver_kms_arn
-          name: atlantis-environment          
+          name: atlantis-environment
     extraArgs:
       - --parallel-pool-size=15
     github: {} # Patch this from Terraform


### PR DESCRIPTION
This pull request introduces a new shared secret for Docker Hub tokens and integrates it into the Atlantis application configuration. The changes ensure that the token is securely referenced and available for use in the application.

### Addition of Docker Hub token configuration:

* [`apps/atlantis/externalsecret.yaml`](diffhunk://#diff-bf58e0431f4d528b04dd1555e727ee7c8b115548ea1ea1e2578deae42209c60fR261-R264): Added a new secret entry for `SHARED_docker_hub_token`, referencing the "Github Actions Token" property from the "Docker Cloud" key.
* [`apps/atlantis/release.yaml`](diffhunk://#diff-1cb3b68926f9c9c4b669db8175b5313eab827be19a289450f7f247f658bf8b19R253-R256): Included the `SHARED_docker_hub_token` environment variable, securely referencing the new secret in the Atlantis environment.