### PR TITLE
chore(secrets): add developer platform AWS access keys to external secrets

### DIFF
--- a/apps/atlantis/externalsecret.yaml
+++ b/apps/atlantis/externalsecret.yaml
@@ -266,3 +266,12 @@ spec:
       remoteRef:
         key: Hardened Account EBS Volume Shared KMS Key
         property: arn
+    - secretKey: DEVELOPER_PLATFORM_DEPLOY_AWS_ACCESS_KEY_ID
+      remoteRef:
+        key: developer-platform Deploy user
+        property: username
+    # trunk-ignore(checkov/CKV_SECRET_6)
+    - secretKey: DEVELOPER_PLATFORM_DEPLOY_AWS_SECRET_ACCESS_KEY
+      remoteRef:
+        key: developer-platform Deploy user
+        property: password

--- a/apps/atlantis/release.yaml
+++ b/apps/atlantis/release.yaml
@@ -258,6 +258,14 @@ spec:
         secretKeyRef:
           key: SHARED_eks_addon_awsebscsidriver_kms_arn
           name: atlantis-environment
+      - name: DEVELOPER_PLATFORM_DEPLOY_AWS_ACCESS_KEY_ID
+        secretKeyRef:
+          key: DEVELOPER_PLATFORM_DEPLOY_AWS_ACCESS_KEY_ID
+          name: atlantis-environment
+      - name: DEVELOPER_PLATFORM_DEPLOY_AWS_SECRET_ACCESS_KEY
+        secretKeyRef:
+          key: DEVELOPER_PLATFORM_DEPLOY_AWS_SECRET_ACCESS_KEY
+          name: atlantis-environment
     extraArgs:
       - --parallel-pool-size=15
     github: {} # Patch this from Terraform


### PR DESCRIPTION
This pull request introduces new AWS credentials for the Developer Platform Deploy user in the Atlantis application configuration. These changes ensure that the application can authenticate and interact with AWS resources using these credentials.

### Addition of AWS credentials:

* [`apps/atlantis/externalsecret.yaml`](diffhunk://#diff-bf58e0431f4d528b04dd1555e727ee7c8b115548ea1ea1e2578deae42209c60fR269-R277): Added `DEVELOPER_PLATFORM_DEPLOY_AWS_ACCESS_KEY_ID` and `DEVELOPER_PLATFORM_DEPLOY_AWS_SECRET_ACCESS_KEY` as secrets with corresponding remote references for the Developer Platform Deploy user. These include the `username` and `password` properties.

* [`apps/atlantis/release.yaml`](diffhunk://#diff-1cb3b68926f9c9c4b669db8175b5313eab827be19a289450f7f247f658bf8b19R261-R268): Included environment variables `DEVELOPER_PLATFORM_DEPLOY_AWS_ACCESS_KEY_ID` and `DEVELOPER_PLATFORM_DEPLOY_AWS_SECRET_ACCESS_KEY` with their respective secret key references (`atlantis-environment`).