### PR TITLE
Added cluster-observability and node-observability priorityclass to values

### DIFF
--- a/apps/falco/helm-release.yaml
+++ b/apps/falco/helm-release.yaml
@@ -15,7 +15,7 @@ spec:
         namespace: flux-system
   interval: 1m
   timeout: 15m
-  values
+  values:
     podPriorityClassName: node-observability
     falcosidekick:
       priorityClassName: cluster-observability


### PR DESCRIPTION
All covered except for metacollector which doesn't seem to support priorityclasses via Helm as of now.

Signed-off-by: Willi Carlsen <carlsenwilli@gmail.com>
