### PR TITLE
Improve falco daemonset rollout strategy to avoid context deadline failure on helmrelease

### DIFF
--- a/apps/falco/helm-release.yaml
+++ b/apps/falco/helm-release.yaml
@@ -16,6 +16,11 @@ spec:
   interval: 1m
   timeout: 15m
   values:
+    controller:
+      updateStrategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 25%
     podPriorityClassName: node-observability
     falcosidekick:
       priorityClassName: cluster-observability


### PR DESCRIPTION
This is very common with daemonsets that only have maxunavailable set to 1 for "larger" clusters. Let's rollover 25% at a time.

<img width="1487" height="90" alt="image" src="https://github.com/user-attachments/assets/6ce3cb2f-3447-4348-b7da-d039f5467532" />

Signed-off-by: Willi Carlsen <carlsenwilli@gmail.com>
