### PR TITLE
Added priorityclass and admission webhook replicas=3 to KEDA

### DIFF
--- a/sources/keda.yaml
+++ b/sources/keda.yaml
@@ -8,5 +8,5 @@ spec:
   url: https://kedacore.github.io/charts
   values:
     webhooks:
-      replicaCount: 1
+      replicaCount: 3
     priorityClassName: "system-cluster-critical"

--- a/sources/keda.yaml
+++ b/sources/keda.yaml
@@ -6,3 +6,7 @@ metadata:
 spec:
   interval: 5m0s
   url: https://kedacore.github.io/charts
+  values:
+    webhooks:
+      replicaCount: 1
+    priorityClassName: "system-cluster-critical"


### PR DESCRIPTION
* You normally don't want to run a low replicacount on your admission webhook, since it can be blocking
* Priorityclasses is alway a good idea

Signed-off-by: Willi Carlsen <carlsenwilli@gmail.com>
