### PR TITLE
Prepare for upgrade to Traefik helm chart V37

### DIFF
--- a/apps/grafana/release.yaml
+++ b/apps/grafana/release.yaml
@@ -109,7 +109,7 @@ spec:
         extraRules:
           - apiGroups: ["traefik.containo.us", "traefik.io"]
             resources: ["ingressroutes", "middlewares", "tlsoptions"]
-            verbs: [ "list", "watch" ]
+            verbs: ["list", "watch"]
       customResourceState:
         enabled: true
         config:
@@ -126,8 +126,8 @@ spec:
                       type: Info
                       info:
                         labelsFromPath:
-                          name: [ metadata, name ]
-                          namespace: [ metadata, namespace ]
+                          name: [metadata, name]
+                          namespace: [metadata, namespace]
               - groupVersionKind:
                   group: traefik.io
                   version: v1alpha1
@@ -139,8 +139,8 @@ spec:
                       type: Info
                       info:
                         labelsFromPath:
-                          name: [ metadata, name ]
-                          namespace: [ metadata, namespace ]
+                          name: [metadata, name]
+                          namespace: [metadata, namespace]
               - groupVersionKind:
                   group: traefik.io
                   version: v1alpha1
@@ -152,8 +152,8 @@ spec:
                       type: Info
                       info:
                         labelsFromPath:
-                          name: [ metadata, name ]
-                          namespace: [ metadata, namespace ]
+                          name: [metadata, name]
+                          namespace: [metadata, namespace]
               - groupVersionKind:
                   group: traefik.containo.us
                   version: v1alpha1
@@ -165,8 +165,8 @@ spec:
                       type: Info
                       info:
                         labelsFromPath:
-                          name: [ metadata, name ]
-                          namespace: [ metadata, namespace ]
+                          name: [metadata, name]
+                          namespace: [metadata, namespace]
               - groupVersionKind:
                   group: traefik.containo.us
                   version: v1alpha1
@@ -178,8 +178,8 @@ spec:
                       type: Info
                       info:
                         labelsFromPath:
-                          name: [ metadata, name ]
-                          namespace: [ metadata, namespace ]
+                          name: [metadata, name]
+                          namespace: [metadata, namespace]
               - groupVersionKind:
                   group: traefik.containo.us
                   version: v1alpha1
@@ -191,8 +191,8 @@ spec:
                       type: Info
                       info:
                         labelsFromPath:
-                          name: [ metadata, name ]
-                          namespace: [ metadata, namespace ]
+                          name: [metadata, name]
+                          namespace: [metadata, namespace]
     prometheus-node-exporter:
       enabled: true
       podLabels:
@@ -209,7 +209,7 @@ spec:
 
     prometheus-operator-crds:
       # Set this to true when removing the old Prometheus stack
-      enabled: false
+      enabled: true
     extraObjects:
       - apiVersion: monitoring.coreos.com/v1
         kind: ServiceMonitor

--- a/apps/traefik-blue-variant/release.yaml
+++ b/apps/traefik-blue-variant/release.yaml
@@ -37,9 +37,9 @@ spec:
         expose: true
       websecure:
         expose: false
-    globalArguments:
-      - "--global.checknewversion"
-      - "--entryPoints.web.forwardedHeaders.insecure"
+      web:
+        forwardedHeaders:
+          insecure: true
     additionalArguments:
       - "--metrics.prometheus"
     logs:

--- a/apps/traefik-green-variant/release.yaml
+++ b/apps/traefik-green-variant/release.yaml
@@ -37,9 +37,9 @@ spec:
         expose: true
       websecure:
         expose: false
-    globalArguments:
-      - "--global.checknewversion"
-      - "--entryPoints.web.forwardedHeaders.insecure"
+      web:
+        forwardedHeaders:
+          insecure: true
     additionalArguments:
       - "--metrics.prometheus"
     logs:


### PR DESCRIPTION
This pull request updates configuration files for Grafana and both Traefik variants to enable new monitoring features and adjust HTTP header forwarding settings. The changes focus on improving Prometheus integration and refining Traefik's argument structure for better security and maintainability.

**Monitoring and Prometheus Integration:**

* Enabled `prometheus-operator-crds` in `apps/grafana/release.yaml`, preparing the stack for enhanced Prometheus monitoring and service discovery.

**Traefik Configuration Refactoring:**

* In both `apps/traefik-blue-variant/release.yaml` and `apps/traefik-green-variant/release.yaml`, replaced the use of `globalArguments` for forwarded headers with a more structured configuration under `web.forwardedHeaders.insecure`, improving clarity and maintainability. [[1]](diffhunk://#diff-93e713351a6a14c22f705f656bf477ead6469be07b30c69eee44f3c063b6bf99L40-R42) [[2]](diffhunk://#diff-e96152607a97b7a8556255af514a134f855e0393dd5c95c2afd2eaa9ee0f2d2aL40-R42)
* Removed the `--global.checknewversion` argument from both Traefik variant configs, streamlining startup arguments and potentially reducing unnecessary version checks. [[1]](diffhunk://#diff-93e713351a6a14c22f705f656bf477ead6469be07b30c69eee44f3c063b6bf99L40-R42) [[2]](diffhunk://#diff-e96152607a97b7a8556255af514a134f855e0393dd5c95c2afd2eaa9ee0f2d2aL40-R42)