### PR TITLE
Remove Terragrunt noise from globally from Atlantis

### DIFF
--- a/apps/atlantis/release.yaml
+++ b/apps/atlantis/release.yaml
@@ -21,6 +21,8 @@ spec:
     basicAuth: {} # Patch this from Terraform
     disableApply: true
     disableApplyAll: true
+    environment:
+      TG_LOG_FORMAT: bare
     environmentSecrets:
       - name: CONFLUENT_KAFKA_PROD_PROMETHEUS_METRICS_EXPORTER_HELLMAN_API_KEY
         secretKeyRef:


### PR DESCRIPTION
"_If you prefer that Terragrunt terminal output look more like that from tofu or terraform, you can use the --log-format bare flag (or set the environment variable TG_LOG_FORMAT=bare) to reduce the verbosity of the output_"

See https://terragrunt.gruntwork.io/docs/getting-started/quick-start/#tutorial for docs.

Signed-off-by: Willi Carlsen <carlsenwilli@gmail.com>
