### PR TITLE
Added resources to traefik-blue variant

### DIFF
--- a/apps/traefik-blue-variant/release.yaml
+++ b/apps/traefik-blue-variant/release.yaml
@@ -56,3 +56,9 @@ spec:
       kubernetesIngress:
         enabled: true
     priorityClassName: cluster-infrastructure
+    resources:
+      requests:
+        cpu: 150m
+        memory: 512Mi
+      limits:
+        memory: 512Mi


### PR DESCRIPTION
We will do the same with the green variant afterwards, but this is a general improvement and for our traefik blue/green switch procedure test on Monday.

See current resource usage 
<img width="1902" height="119" alt="image" src="https://github.com/user-attachments/assets/36b30afe-5508-44f8-8650-7890ac3738d2" />
and for 4 day looking back
<img width="1588" height="955" alt="image" src="https://github.com/user-attachments/assets/7023de66-d7ed-4893-9997-d502e47f29a5" />


Signed-off-by: Willi Carlsen <carlsenwilli@gmail.com>
