### PR TITLE
Works towards no keda patching

### DIFF
--- a/apps/keda/helm-release.yaml
+++ b/apps/keda/helm-release.yaml
@@ -4,6 +4,7 @@ metadata:
   name: keda
   namespace: flux-system
 spec:
+  serviceAccountName: helm-controller
   targetNamespace: keda
   chart:
     spec:

--- a/apps/keda/helm-release.yaml
+++ b/apps/keda/helm-release.yaml
@@ -2,7 +2,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: keda
-  namespace: flux-system
+  namespace: keda
 spec:
   serviceAccountName: helm-controller
   targetNamespace: keda


### PR DESCRIPTION
- HelmReleases are always stored in the namespace where the product is installed. Hence keda is the right namespace.
- We only patch serviceAccountName, but it is always helm-controller for HelmReleases, so there is no need to patch it. Better keep it directly in platform-apps.

This pull request updates the namespace configuration for the KEDA Helm release to improve separation of concerns and security. The most important changes are:

Namespace configuration:

* Changed the `namespace` for the `keda` HelmRelease from `flux-system` to `keda`, ensuring the release is managed in its own dedicated namespace.
* Added `serviceAccountName: helm-controller` to specify which service account should be used for the Helm release, enhancing security and access control.
* Confirmed that the `targetNamespace` remains set to `keda`, ensuring KEDA resources are deployed in the correct namespace.