### PR TITLE
chore(deps): add resource requests and limits for keda components

### DIFF
--- a/apps/keda/helm-release.yaml
+++ b/apps/keda/helm-release.yaml
@@ -27,3 +27,22 @@ spec:
     webhooks:
       replicaCount: 3
     priorityClassName: "system-cluster-critical"
+    resources:
+      operator:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: 10m
+          memory: 256Mi
+      metricServer:
+        limits:
+          memory: 128Mi
+        requests:
+          cpu: 1m
+          memory: 128Mi
+      webhooks:
+        limits:
+          memory: 64Mi
+        requests:
+          cpu: 1m
+          memory: 64Mi


### PR DESCRIPTION
This pull request introduces resource requests and limits for the `operator`, `metricServer`, and `webhooks` components in the `apps/keda/helm-release.yaml` file. These changes help ensure that each component has defined CPU and memory allocations, which improves resource management and stability in Kubernetes deployments.

Resource configuration updates:

* Defined CPU and memory requests and limits for the `operator` to ensure predictable resource usage.
* Added resource requests and limits for the `metricServer` to control its memory and CPU consumption.
* Set resource requests and limits for `webhooks` to manage its resource allocation.