### PR TITLE
Adding policy-reporter for Kyverno

### DIFF
--- a/apps/policy-reporter/kustomization.yaml
+++ b/apps/policy-reporter/kustomization.yaml
@@ -1,6 +1,5 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: policy-reporter
 resources:
   - release.yaml

--- a/apps/policy-reporter/kustomization.yaml
+++ b/apps/policy-reporter/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: policy-reporter
+resources:
+  - release.yaml

--- a/apps/policy-reporter/release.yaml
+++ b/apps/policy-reporter/release.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: policy-reporter
+  namespace: policy-reporter
+spec:
+  releaseName: policy-reporter
+  chart:
+    spec:
+      chart: policy-reporter
+      version: 3.5.0
+      sourceRef:
+        kind: HelmRepository
+        name: policy-reporter
+        namespace: flux-system
+  interval: 1m0s
+  targetNamespace: policy-reporter
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    ui:
+      enabled: true
+    kyvernoPlugin:
+      enabled: true

--- a/apps/policy-reporter/release.yaml
+++ b/apps/policy-reporter/release.yaml
@@ -1,11 +1,12 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: policy-reporter
   namespace: policy-reporter
 spec:
   releaseName: policy-reporter
+  serviceAccountName: helm-controller
   chart:
     spec:
       chart: policy-reporter

--- a/sources/kustomization.yaml
+++ b/sources/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - goldpinger.yaml
   - grafana.yaml
   - kyverno.yaml
+  - policy-reporter.yaml
   - metrics-server.yaml
   - nvidia-device-plugin.yaml
   - podinfo.yaml

--- a/sources/policy-reporter.yaml
+++ b/sources/policy-reporter.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: policy-reporter
+  namespace: flux-system
+spec:
+  interval: 5m0s
+  url: https://kyverno.github.io/policy-reporter


### PR DESCRIPTION
This pull request introduces the Policy Reporter service into the deployment, integrating it with Flux and Helm for automated management. The main changes set up the necessary Helm repository, define the Helm release for Policy Reporter (including enabling the UI and Kyverno plugin), and update the kustomization files to include these new resources.

**Policy Reporter integration:**

* Added `sources/policy-reporter.yaml` to define the Policy Reporter Helm repository for Flux to pull the chart from the official Kyverno source.
* Created `apps/policy-reporter/release.yaml` to specify the HelmRelease for Policy Reporter, including configuration to enable the UI and Kyverno plugin, set install/upgrade remediation, and chart version.
* Added `apps/policy-reporter/kustomization.yaml` to manage the Policy Reporter deployment via Kustomize in the `policy-reporter` namespace.

**Deployment configuration updates:**

* Updated `sources/kustomization.yaml` to include `policy-reporter.yaml` in the list of managed resources, ensuring the new Helm repository is part of the deployment process.