### PR TITLE
Propagate VPC ID to aws-lb-controller

### DIFF
--- a/apps/aws-lb-controller/manifests/Deployment-aws-lb-controller-aws-load-balancer-controller.yml
+++ b/apps/aws-lb-controller/manifests/Deployment-aws-lb-controller-aws-load-balancer-controller.yml
@@ -39,6 +39,7 @@ spec:
             - --cluster-name=${flux_cluster_name}
             - --ingress-class=alb
             - --aws-region=${flux_aws_region}
+            - --aws-vpc-id=${flux_vpc_id}
             - --watch-namespace=aws-lb-controller
           securityContext:
             allowPrivilegeEscalation: false

--- a/apps/aws-lb-controller/release.yaml
+++ b/apps/aws-lb-controller/release.yaml
@@ -34,3 +34,4 @@ spec:
       limits:
         memory: 64Mi
     watchNamespace: aws-lb-controller
+    vpcId: ${flux_vpc_id}


### PR DESCRIPTION
Prevent AWS Loadbalancer Controller from breaking if instance metadata service http hop limit is decreased from 2 to 1, which is also the security standard to prevent pods from accessing the EC2 instances metadata service. If hop limit would change the controller can no longer discover VPC ID via the metadata service and we would need to provide it, to prevent errors.

Linked to this https://github.com/dfds/infrastructure-modules/pull/2256