### PR TITLE
Remove invalid ECR check

### DIFF
--- a/apps/kyverno/policies/hard-requirement/kustomization.yaml
+++ b/apps/kyverno/policies/hard-requirement/kustomization.yaml
@@ -3,5 +3,4 @@ kind: Kustomization
 resources:
   - require-external-secret-label.yaml
   - require-probes.yaml
-  - restrict-ecr-images.yaml
   - require-hpa.yaml


### PR DESCRIPTION
We cannot validate if teams own ECR's has the correct permissions following option 2 here https://wiki.dfds.cloud/en/playbooks/ecr-pull-kubernetes