### PR TITLE
Reduce Falco patching in Flux. Some patching had to remain

### DIFF
--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -33,7 +33,7 @@ spec:
       prometheus_metrics_enabled: true
     program_output:
         enabled: true
-        program: "jq '{channel: ${flux_falco_program_output_slack_channel}, text: .output}' | curl -d @- -X POST ${flux_falco_program_output_slack_webhookurl}"
+        program: "jq '{channel: \"#falco-event-valyria\", text: .output}' | curl -d @- -X POST ${flux_falco_program_output_slack_webhookurl}"
     falcosidekick:
       enabled: true
       priorityClassName: cluster-observability

--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -33,7 +33,7 @@ spec:
       prometheus_metrics_enabled: true
     program_output:
         enabled: true
-        program: !!str jq '{channel: \"${flux_falco_program_output_channel}\", text: .output}' | curl -d @- -X POST ${flux_falco_program_output_webhookurl}
+        program: "!!str jq '{channel: \"${flux_falco_program_output_channel}\", text: .output}' | curl -d @- -X POST ${flux_falco_program_output_webhookurl}"
     falcosidekick:
       enabled: true
       priorityClassName: cluster-observability

--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -33,7 +33,7 @@ spec:
       prometheus_metrics_enabled: true
     program_output:
         enabled: true
-        program: "!!str jq '{channel: \"${flux_falco_program_output_channel}\", text: .output}' | curl -d @- -X POST ${flux_falco_program_output_webhookurl}"
+        program: "echo lala"
     falcosidekick:
       enabled: true
       priorityClassName: cluster-observability

--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -39,7 +39,7 @@ spec:
       priorityClassName: cluster-observability
       config:
         slack:
-          webhookurl: "${flux_falco_sidekick_slack_alert_webhookurl}"
+          webhookurl: "!!str ${flux_falco_sidekick_slack_alert_webhookurl}"
           channel: "!!str ${flux_falco_sidekick_slack_alert_channel}" #https://yaml.org/spec/1.1/current.html#:~:text=2.4.-,Tags,-In%20YAML%2C
           minimumpriority: "critical"
       resources:

--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -34,6 +34,11 @@ spec:
     falcosidekick:
       enabled: true
       priorityClassName: cluster-observability
+      config:
+        slack:
+          webhookurl: ${flux_falco_sidekick_slack_webhookurl}
+          channel: ${flux_falco_sidekick_slack_channel}
+          minimumpriority: ${flux_falco_sidekick_slack_minimumpriority}
       resources:
         requests:
           cpu: 5m

--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -33,9 +33,7 @@ spec:
       prometheus_metrics_enabled: true
     program_output:
         enabled: true
-        program: |-
-          jq --arg ch '${flux_falco_program_output_channel}' '{channel:$ch,text:.output}' | \
-          curl -d @- -X POST ${flux_falco_program_output_webhookurl}
+        program: !!str jq '{channel: \"${flux_falco_program_output_channel}\", text: .output}' | curl -d @- -X POST ${flux_falco_program_output_webhookurl}
     falcosidekick:
       enabled: true
       priorityClassName: cluster-observability

--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -33,7 +33,7 @@ spec:
       prometheus_metrics_enabled: true
     program_output:
         enabled: true
-        program: "jq '{channel: \"${flux_falco_program_output_slack_channel}\", text: .output}' | curl -d @- -X POST ${flux_falco_program_output_slack_webhookurl}"
+        program: "jq '{channel: ${flux_falco_program_output_slack_channel}, text: .output}' | curl -d @- -X POST ${flux_falco_program_output_slack_webhookurl}"
     falcosidekick:
       enabled: true
       priorityClassName: cluster-observability

--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -31,6 +31,9 @@ spec:
         enabled: true
     webserver:
       prometheus_metrics_enabled: true
+    program_output:
+        enabled: true
+        program: "jq '{channel: \"${flux_falco_program_output_slack_channel}\", text: .output}' | curl -d @- -X POST ${flux_falco_program_output_slack_webhookurl}"
     falcosidekick:
       enabled: true
       priorityClassName: cluster-observability

--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -33,7 +33,9 @@ spec:
       prometheus_metrics_enabled: true
     program_output:
         enabled: true
-        program: "jq '{channel: ${flux_falco_program_output_channel}, text: .output}' | curl -d @- -X POST ${flux_falco_program_output_webhookurl}"
+        program: |-
+          jq --arg ch '${flux_falco_program_output_channel}' '{channel:$ch,text:.output}' | \
+          curl -d @- -X POST ${flux_falco_program_output_webhookurl}
     falcosidekick:
       enabled: true
       priorityClassName: cluster-observability

--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -33,7 +33,7 @@ spec:
       prometheus_metrics_enabled: true
     program_output:
         enabled: true
-        program: "jq '{channel: \"#falco-event-valyria\", text: .output}' | curl -d @- -X POST ${flux_falco_program_output_slack_webhookurl}"
+        program: ${flux_falco_program_output_program}
     falcosidekick:
       enabled: true
       priorityClassName: cluster-observability

--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -17,6 +17,34 @@ spec:
   interval: 1m
   timeout: 15m
   values:
+    driver:
+      kind: modern_ebpf
+      modern_ebpf:
+        leastPrivileged: true
+    metrics:
+      enabled: true
+    collectors:
+      kubernetes:
+        enabled: true # Experimental
+    grafana:
+      dashboards:
+        enabled: true
+    webserver:
+      prometheus_metrics_enabled: true
+    falcosidekick:
+      enabled: true
+      priorityClassName: cluster-observability
+      resources:
+        requests:
+          cpu: 5m
+          memory: 256Mi
+        limits:
+          memory: 256Mi
+      webui:
+        enabled: true
+        priorityClassName: cluster-observability
+        redis:
+          priorityClassName: cluster-observability
     resources:
       requests:
         cpu: 25m
@@ -30,15 +58,3 @@ spec:
           rollingUpdate:
             maxUnavailable: 25%
     podPriorityClassName: node-observability
-    falcosidekick:
-      priorityClassName: cluster-observability
-      resources:
-        requests:
-          cpu: 5m
-          memory: 256Mi
-        limits:
-          memory: 256Mi
-      webui:
-        priorityClassName: cluster-observability
-        redis:
-          priorityClassName: cluster-observability

--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -31,8 +31,6 @@ spec:
         enabled: true
     webserver:
       prometheus_metrics_enabled: true
-    program_output:
-        enabled: true
     falcosidekick:
       enabled: true
       priorityClassName: cluster-observability

--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -33,7 +33,7 @@ spec:
       prometheus_metrics_enabled: true
     program_output:
         enabled: true
-        program: "!!str jq '{channel: "${flux_falco_program_output_channel}", text: .output}' | curl -d @- -X POST ${flux_falco_program_output_webhookurl}" #https://yaml.org/spec/1.1/current.html#:~:text=2.4.-,Tags,-In%20YAML%2C
+        program: "!!str jq '{channel: \"${flux_falco_program_output_channel}\", text: .output}' | curl -d @- -X POST ${flux_falco_program_output_webhookurl}" #https://yaml.org/spec/1.1/current.html#:~:text=2.4.-,Tags,-In%20YAML%2C
     falcosidekick:
       enabled: true
       priorityClassName: cluster-observability

--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -41,7 +41,7 @@ spec:
         slack:
           webhookurl: "!!str ${flux_falco_sidekick_slack_alert_webhookurl}"
           channel: "!!str ${flux_falco_sidekick_slack_alert_channel}" #https://yaml.org/spec/1.1/current.html#:~:text=2.4.-,Tags,-In%20YAML%2C
-          minimumpriority: "critical"
+          minimumpriority: "notification"
       resources:
         requests:
           cpu: 5m

--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -39,8 +39,8 @@ spec:
       priorityClassName: cluster-observability
       config:
         slack:
-          webhookurl: "!!str ${flux_falco_sidekick_slack_alert_webhookurl}"
-          channel: "!!str ${flux_falco_sidekick_slack_alert_channel}" #https://yaml.org/spec/1.1/current.html#:~:text=2.4.-,Tags,-In%20YAML%2C
+          webhookurl: "${flux_falco_sidekick_slack_alert_webhookurl}"
+          channel: "!!str ${flux_falco_sidekick_slack_alert_channel}"
           minimumpriority: "informational"
       resources:
         requests:

--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -33,7 +33,7 @@ spec:
       prometheus_metrics_enabled: true
     program_output:
         enabled: true
-        program: !!str "${flux_falco_program_output_program}"
+        program: "!!str ${flux_falco_program_output_program}"
     falcosidekick:
       enabled: true
       priorityClassName: cluster-observability

--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -33,7 +33,6 @@ spec:
       prometheus_metrics_enabled: true
     program_output:
         enabled: true
-        program: "echo lala"
     falcosidekick:
       enabled: true
       priorityClassName: cluster-observability

--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -33,14 +33,14 @@ spec:
       prometheus_metrics_enabled: true
     program_output:
         enabled: true
-        program: ${flux_quote}${flux_falco_program_output_program}${flux_quote}
+        program: !!str "${flux_falco_program_output_program}"
     falcosidekick:
       enabled: true
       priorityClassName: cluster-observability
       config:
         slack:
-          webhookurl: ${flux_quote}${flux_falco_sidekick_slack_alert_webhookurl}${flux_quote}
-          channel: ${flux_quote}${flux_falco_sidekick_slack_alert_channel}${flux_quote}
+          webhookurl: !!str "${flux_falco_sidekick_slack_alert_webhookurl}"
+          channel: !!str "${flux_falco_sidekick_slack_alert_channel}"
           minimumpriority: "critical"
       resources:
         requests:

--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -37,7 +37,6 @@ spec:
       config:
         slack:
           webhookurl: "${flux_falco_sidekick_slack_alert_webhookurl}"
-          channel: "!!str ${flux_falco_sidekick_slack_alert_channel}"
           minimumpriority: "informational"
       resources:
         requests:

--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -33,8 +33,7 @@ spec:
       prometheus_metrics_enabled: true
     program_output:
         enabled: true
-        program: >
-          jq '{channel: ${flux_falco_program_output_channel}, text: .output}' | curl -d @- -X POST ${flux_falco_program_output_webhookurl} #https://yaml.org/spec/1.1/current.html#:~:text=2.4.-,Tags,-In%20YAML%2C
+        program: "jq '{channel: ${flux_falco_program_output_channel}, text: .output}' | curl -d @- -X POST ${flux_falco_program_output_webhookurl}"
     falcosidekick:
       enabled: true
       priorityClassName: cluster-observability

--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -34,7 +34,7 @@ spec:
     program_output:
         enabled: true
         program: >
-          jq '{\"channel\":\"${flux_falco_program_output_channel}\",\"text\":\".output\"}' | curl -d @- -X POST ${flux_falco_program_output_webhookurl} #https://yaml.org/spec/1.1/current.html#:~:text=2.4.-,Tags,-In%20YAML%2C
+          jq '{channel: ${flux_falco_program_output_channel}, text: .output}' | curl -d @- -X POST ${flux_falco_program_output_webhookurl} #https://yaml.org/spec/1.1/current.html#:~:text=2.4.-,Tags,-In%20YAML%2C
     falcosidekick:
       enabled: true
       priorityClassName: cluster-observability

--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -37,7 +37,7 @@ spec:
       config:
         slack:
           webhookurl: "${flux_falco_sidekick_slack_alert_webhookurl}"
-          minimumpriority: "informational"
+          minimumpriority: "critical"
       resources:
         requests:
           cpu: 5m

--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -33,7 +33,7 @@ spec:
       prometheus_metrics_enabled: true
     program_output:
         enabled: true
-        program: "!!str ${flux_falco_program_output_program}" #https://yaml.org/spec/1.1/current.html#:~:text=2.4.-,Tags,-In%20YAML%2C
+        program: "!!str jq '{channel: "${flux_falco_program_output_channel}", text: .output}' | curl -d @- -X POST ${flux_falco_program_output_webhookurl}" #https://yaml.org/spec/1.1/current.html#:~:text=2.4.-,Tags,-In%20YAML%2C
     falcosidekick:
       enabled: true
       priorityClassName: cluster-observability

--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -39,8 +39,8 @@ spec:
       priorityClassName: cluster-observability
       config:
         slack:
-          webhookurl: !!str "${flux_falco_sidekick_slack_alert_webhookurl}"
-          channel: !!str "${flux_falco_sidekick_slack_alert_channel}"
+          webhookurl: "!!str ${flux_falco_sidekick_slack_alert_webhookurl}"
+          channel: "!!str ${flux_falco_sidekick_slack_alert_channel}"
           minimumpriority: "critical"
       resources:
         requests:

--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -33,14 +33,14 @@ spec:
       prometheus_metrics_enabled: true
     program_output:
         enabled: true
-        program: "!!str ${flux_falco_program_output_program}"
+        program: "!!str ${flux_falco_program_output_program}" #https://yaml.org/spec/1.1/current.html#:~:text=2.4.-,Tags,-In%20YAML%2C
     falcosidekick:
       enabled: true
       priorityClassName: cluster-observability
       config:
         slack:
-          webhookurl: "!!str ${flux_falco_sidekick_slack_alert_webhookurl}"
-          channel: "!!str ${flux_falco_sidekick_slack_alert_channel}"
+          webhookurl: "${flux_falco_sidekick_slack_alert_webhookurl}"
+          channel: "!!str ${flux_falco_sidekick_slack_alert_channel}" #https://yaml.org/spec/1.1/current.html#:~:text=2.4.-,Tags,-In%20YAML%2C
           minimumpriority: "critical"
       resources:
         requests:

--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -36,9 +36,9 @@ spec:
       priorityClassName: cluster-observability
       config:
         slack:
-          webhookurl: ${flux_falco_sidekick_slack_webhookurl}
-          channel: ${flux_falco_sidekick_slack_channel}
-          minimumpriority: ${flux_falco_sidekick_slack_minimumpriority}
+          webhookurl: ${flux_falco_sidekick_slack_alert_webhookurl}
+          channel: ${flux_falco_sidekick_slack_alert_channel}
+          minimumpriority: "critical"
       resources:
         requests:
           cpu: 5m

--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -41,7 +41,7 @@ spec:
         slack:
           webhookurl: "!!str ${flux_falco_sidekick_slack_alert_webhookurl}"
           channel: "!!str ${flux_falco_sidekick_slack_alert_channel}" #https://yaml.org/spec/1.1/current.html#:~:text=2.4.-,Tags,-In%20YAML%2C
-          minimumpriority: "notification"
+          minimumpriority: "informational"
       resources:
         requests:
           cpu: 5m

--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -33,14 +33,14 @@ spec:
       prometheus_metrics_enabled: true
     program_output:
         enabled: true
-        program: ${flux_falco_program_output_program}
+        program: ${flux_quote}${flux_falco_program_output_program}${flux_quote}
     falcosidekick:
       enabled: true
       priorityClassName: cluster-observability
       config:
         slack:
-          webhookurl: ${flux_falco_sidekick_slack_alert_webhookurl}
-          channel: ${flux_falco_sidekick_slack_alert_channel}
+          webhookurl: ${flux_quote}${flux_falco_sidekick_slack_alert_webhookurl}${flux_quote}
+          channel: ${flux_quote}${flux_falco_sidekick_slack_alert_channel}${flux_quote}
           minimumpriority: "critical"
       resources:
         requests:

--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -38,7 +38,7 @@ spec:
         slack:
           webhookurl: ${flux_falco_sidekick_slack_alert_webhookurl}
           channel: ${flux_falco_sidekick_slack_alert_channel}
-          minimumpriority: "informational"
+          minimumpriority: "critical"
       resources:
         requests:
           cpu: 5m

--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -38,7 +38,7 @@ spec:
         slack:
           webhookurl: ${flux_falco_sidekick_slack_alert_webhookurl}
           channel: ${flux_falco_sidekick_slack_alert_channel}
-          minimumpriority: "critical"
+          minimumpriority: "informational"
       resources:
         requests:
           cpu: 5m

--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -33,7 +33,8 @@ spec:
       prometheus_metrics_enabled: true
     program_output:
         enabled: true
-        program: "!!str jq '{channel: \"${flux_falco_program_output_channel}\", text: .output}' | curl -d @- -X POST ${flux_falco_program_output_webhookurl}" #https://yaml.org/spec/1.1/current.html#:~:text=2.4.-,Tags,-In%20YAML%2C
+        program: >
+          jq '{\"channel\":\"${flux_falco_program_output_channel}\",\"text\":\".output\"}' | curl -d @- -X POST ${flux_falco_program_output_webhookurl} #https://yaml.org/spec/1.1/current.html#:~:text=2.4.-,Tags,-In%20YAML%2C
     falcosidekick:
       enabled: true
       priorityClassName: cluster-observability


### PR DESCRIPTION
This pull request updates the `apps/falco/release.yaml` configuration to enhance observability, enable additional monitoring features, and refactor how `falcosidekick` settings are managed. The main changes include enabling metrics and dashboards, configuring the Falco driver for least privilege, and moving the `falcosidekick` configuration under the `values` section for better structure and flexibility.

**Observability and Monitoring Enhancements**
* Enabled metrics collection (`metrics.enabled`), Grafana dashboards (`grafana.dashboards.enabled`), and Prometheus metrics on the webserver (`webserver.prometheus_metrics_enabled`) to improve monitoring capabilities.
* Enabled experimental Kubernetes collectors to gather more cluster data (`collectors.kubernetes.enabled`).

**Falco Driver Configuration**
* Switched the driver to `modern_ebpf` and enabled `leastPrivileged` mode for improved security.

**Falcosidekick Configuration Refactor**
* Moved and expanded the `falcosidekick` configuration under the `values` section, adding Slack integration, resource requests/limits, and ensuring all components (including `webui` and `redis`) use the `cluster-observability` priority class. [[1]](diffhunk://#diff-051a7ea0a21df43b19ceb853e3fb139749b2c9f4c48961433bd440e7661af298R20-R51) [[2]](diffhunk://#diff-051a7ea0a21df43b19ceb853e3fb139749b2c9f4c48961433bd440e7661af298L33-L44)
* Removed the old, less flexible `falcosidekick` configuration from its previous location.