### PR TITLE
Add new Falco environment variables to Atlantis

### DIFF
--- a/apps/atlantis/externalsecret-atlantis-environment.yaml
+++ b/apps/atlantis/externalsecret-atlantis-environment.yaml
@@ -200,22 +200,6 @@ spec:
       remoteRef:
         key: Slack dfds.slack.com webhooks
         property: "#staging-hellman-alerting (Staging Alert Bot)"
-    - secretKey: STAGING_TF_VAR_falco_slack_alert_webhook_url
-      remoteRef:
-        key: Falco
-        property: slack_alert_webhook_url_staging
-    - secretKey: STAGING_TF_VAR_falco_stream_webhook_url
-      remoteRef:
-        key: Falco
-        property: stream_webhook_url_staging
-    - secretKey: PRODUCTION_TF_VAR_falco_slack_alert_webhook_url
-      remoteRef:
-        key: Falco
-        property: slack_alert_webhook_url_prod
-    - secretKey: PRODUCTION_TF_VAR_falco_stream_webhook_url
-      remoteRef:
-        key: Falco
-        property: stream_webhook_url_prod
     - secretKey: PRODUCTION_ONEPASSWORD_CREDENTIALS_JSON
       remoteRef:
         key: 1Password Connect
@@ -281,3 +265,27 @@ spec:
       remoteRef:
         key: Azure - Offsite Backup
         property: hellman-storage-account-name
+    - secretKey: STAGING_falco_slack_alert_webhook_url
+      remoteRef:
+        key: Slack dfds.slack.com webhooks
+        property: "#falco-alerts-staging-hellman (The All-Seeing Eye)"
+    - secretKey: STAGING_falco_stream_webhook_url
+      remoteRef:
+        key: Slack dfds.slack.com webhooks
+        property: "#falco-events-staging-hellman (The All-Seeing Eye)"
+    - secretKey: PRODUCTION_falco_slack_alert_webhook_url
+      remoteRef:
+        key: Slack dfds.slack.com webhooks
+        property: "#falco-alerts-hellman (The All-Seeing Eye)"
+    - secretKey: PRODUCTION_falco_stream_webhook_url
+      remoteRef:
+        key: Slack dfds.slack.com webhooks
+        property: "#falco-events-hellman (The All-Seeing Eye)"
+    - secretKey: STANDBY_falco_slack_alert_webhook_url
+      remoteRef:
+        key: Slack dfds.slack.com webhooks
+        property: "#falco-alerts-diffie (The All-Seeing Eye)"
+    - secretKey: STANDBY_falco_stream_webhook_url
+      remoteRef:
+        key: Slack dfds.slack.com webhooks
+        property: "#falco-events-diffie (The All-Seeing Eye)"

--- a/apps/atlantis/manifests/StatefulSet-atlantis.yml
+++ b/apps/atlantis/manifests/StatefulSet-atlantis.yml
@@ -302,26 +302,6 @@ spec:
                 secretKeyRef:
                   name: atlantis-environment
                   key: STAGING_TF_VAR_slack_webhook_url
-            - name: STAGING_TF_VAR_falco_slack_alert_webhook_url
-              valueFrom:
-                secretKeyRef:
-                  name: atlantis-environment
-                  key: STAGING_TF_VAR_falco_slack_alert_webhook_url
-            - name: STAGING_TF_VAR_falco_stream_webhook_url
-              valueFrom:
-                secretKeyRef:
-                  name: atlantis-environment
-                  key: STAGING_TF_VAR_falco_stream_webhook_url
-            - name: PRODUCTION_TF_VAR_falco_slack_alert_webhook_url
-              valueFrom:
-                secretKeyRef:
-                  name: atlantis-environment
-                  key: PRODUCTION_TF_VAR_falco_slack_alert_webhook_url
-            - name: PRODUCTION_TF_VAR_falco_stream_webhook_url
-              valueFrom:
-                secretKeyRef:
-                  name: atlantis-environment
-                  key: PRODUCTION_TF_VAR_falco_stream_webhook_url
             - name: PRODUCTION_ONEPASSWORD_CREDENTIALS_JSON
               valueFrom:
                 secretKeyRef:
@@ -402,6 +382,36 @@ spec:
                 secretKeyRef:
                   name: atlantis-environment
                   key: PRODUCTION_velero_azure_storage_account_name
+            - name: STAGING_falco_slack_alert_webhook_url
+              valueFrom:
+                secretKeyRef:
+                  name: atlantis-environment
+                  key: STAGING_falco_slack_alert_webhook_url
+            - name: STAGING_falco_stream_webhook_url
+              valueFrom:
+                secretKeyRef:
+                  name: atlantis-environment
+                  key: STAGING_falco_stream_webhook_url
+            - name: PRODUCTION_falco_slack_alert_webhook_url
+              valueFrom:
+                secretKeyRef:
+                  name: atlantis-environment
+                  key: PRODUCTION_falco_slack_alert_webhook_url
+            - name: PRODUCTION_falco_stream_webhook_url
+              valueFrom:
+                secretKeyRef:
+                  name: atlantis-environment
+                  key: PRODUCTION_falco_stream_webhook_url
+            - name: STANDBY_falco_slack_alert_webhook_url
+              valueFrom:
+                secretKeyRef:
+                  name: atlantis-environment
+                  key: STANDBY_falco_slack_alert_webhook_url
+            - name: STANDBY_falco_stream_webhook_url
+              valueFrom:
+                secretKeyRef:
+                  name: atlantis-environment
+                  key: STANDBY_falco_stream_webhook_url
             - name: ATLANTIS_DISABLE_APPLY
               value: "true"
             - name: ATLANTIS_DISABLE_APPLY_ALL

--- a/apps/atlantis/release.yaml
+++ b/apps/atlantis/release.yaml
@@ -223,22 +223,6 @@ spec:
         secretKeyRef:
           key: STAGING_TF_VAR_slack_webhook_url
           name: atlantis-environment
-      - name: STAGING_TF_VAR_falco_slack_alert_webhook_url
-        secretKeyRef:
-          key: STAGING_TF_VAR_falco_slack_alert_webhook_url
-          name: atlantis-environment
-      - name: STAGING_TF_VAR_falco_stream_webhook_url
-        secretKeyRef:
-          key: STAGING_TF_VAR_falco_stream_webhook_url
-          name: atlantis-environment
-      - name: PRODUCTION_TF_VAR_falco_slack_alert_webhook_url
-        secretKeyRef:
-          key: PRODUCTION_TF_VAR_falco_slack_alert_webhook_url
-          name: atlantis-environment
-      - name: PRODUCTION_TF_VAR_falco_stream_webhook_url
-        secretKeyRef:
-          key: PRODUCTION_TF_VAR_falco_stream_webhook_url
-          name: atlantis-environment
       - name: PRODUCTION_ONEPASSWORD_CREDENTIALS_JSON
         secretKeyRef:
           key: PRODUCTION_ONEPASSWORD_CREDENTIALS_JSON
@@ -302,6 +286,30 @@ spec:
       - name: PRODUCTION_velero_azure_storage_account_name
         secretKeyRef:
           key: PRODUCTION_velero_azure_storage_account_name
+          name: atlantis-environment
+      - name: STAGING_falco_slack_alert_webhook_url
+        secretKeyRef:
+          key: STAGING_falco_slack_alert_webhook_url
+          name: atlantis-environment
+      - name: STAGING_falco_stream_webhook_url
+        secretKeyRef:
+          key: STAGING_falco_stream_webhook_url
+          name: atlantis-environment
+      - name: PRODUCTION_falco_slack_alert_webhook_url
+        secretKeyRef:
+          key: PRODUCTION_falco_slack_alert_webhook_url
+          name: atlantis-environment
+      - name: PRODUCTION_falco_stream_webhook_url
+        secretKeyRef:
+          key: PRODUCTION_falco_stream_webhook_url
+          name: atlantis-environment
+      - name: STANDBY_falco_slack_alert_webhook_url
+        secretKeyRef:
+          key: STANDBY_falco_slack_alert_webhook_url
+          name: atlantis-environment
+      - name: STANDBY_falco_stream_webhook_url
+        secretKeyRef:
+          key: STANDBY_falco_stream_webhook_url
           name: atlantis-environment
     extraArgs:
       - --parallel-pool-size=15


### PR DESCRIPTION
This pull request updates the Falco Slack webhook secret configuration for the Atlantis environment. It replaces the old secret keys and references with new ones that are more consistently named and mapped directly to specific Slack channels for staging, production, and standby environments. The changes ensure that the correct Slack webhooks are used for Falco alerting and event notifications in each environment.

Secret key and environment variable updates:

**Secret references in `externalsecret-atlantis-environment.yaml`:**
- Removed old Falco secret keys and references, which used the `TF_VAR` naming convention and referenced a generic `Falco` key.
- Added new secret keys for Falco alert and event webhooks for staging, production, and standby environments, each mapped to specific Slack channels with descriptive names.

**Environment variable mappings in `release.yaml`:**
- Removed old environment variable mappings that referenced the previous Falco secret keys.
- Added new environment variable mappings for the updated Falco Slack alert and event webhook secrets, including for the standby environment.