### PR TITLE
Don't put new Renovate PRs on hold

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -40,8 +40,7 @@
                 "minor"
             ],
             "addLabels": [
-                "release:minor",
-                "on-hold"
+                "release:minor"
             ],
             "minimumReleaseAge": "7 days",
             "automerge": false,
@@ -54,8 +53,7 @@
                 "major"
             ],
             "addLabels": [
-                "release:major",
-                "on-hold"
+                "release:major"
             ],
             "minimumReleaseAge": "14 days",
             "automerge": false,


### PR DESCRIPTION
This pull request makes a minor update to the `renovate.json` configuration file by adjusting the labels applied to Renovate PRs for minor and major releases. The "on-hold" label will no longer be automatically added to these PRs. 

- Removed the "on-hold" label from the `addLabels` list for both minor and major release PRs in `renovate.json` [[1]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L43-R43) [[2]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L57-R56)