### PR TITLE
Add helm chart rendering on goldpinger

### DIFF
--- a/.github/workflows/update-crds-and-manifests.yaml
+++ b/.github/workflows/update-crds-and-manifests.yaml
@@ -4,6 +4,7 @@ on:
     paths:
       - "**/sources.yaml"
       - "**/release.yaml"
+      - "**/Makefile"
 jobs:
   update-crds-and-manifests:
     runs-on: ubuntu-latest

--- a/apps/goldpinger/Makefile
+++ b/apps/goldpinger/Makefile
@@ -1,0 +1,24 @@
+SHELL = /usr/bin/env bash
+
+# Find HelmRelease and Source files
+release := $(shell yq '. | select(.kind=="HelmRelease") | filename' *.yaml)
+source := $(shell yq '. | select(.kind=="HelmRepository") | filename' *.yaml)
+
+# Fetch data from HelmRepository and HelmRelease
+name := $(shell yq '.metadata.name' $(release))
+namespace := $(shell yq '.metadata.namespace' $(release))
+version := $(shell yq '.spec.chart.spec.version' $(release))
+chart := $(shell yq '.spec.chart.spec.chart' $(release))
+values := yq '.spec.values' $(release)
+url := $(shell yq '.spec.url' $(source))
+
+# Run all tasks
+all: manifests
+
+# Render template with helm (filtering away noisy annotations when diffing)
+manifests: $(release) $(source)
+	mkdir -p manifests
+	rm -rf manifests/*
+	helm template $(name) $(chart) --repo $(url) --version $(version) --namespace $(namespace) --skip-crds -f <(echo "$$($(values))") | grep -vE "helm.sh/chart|app.kubernetes.io/version" | yq -s '"manifests/" + .kind + "-" + .metadata.name'
+
+.PHONY: all manifests

--- a/apps/goldpinger/manifests/ClusterRole-goldpinger-clusterrole.yml
+++ b/apps/goldpinger/manifests/ClusterRole-goldpinger-clusterrole.yml
@@ -1,0 +1,14 @@
+---
+# Source: goldpinger/templates/clusterrole.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: goldpinger-clusterrole
+  labels:
+    app.kubernetes.io/name: goldpinger
+    app.kubernetes.io/instance: goldpinger
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list"]

--- a/apps/goldpinger/manifests/ClusterRoleBinding-goldpinger-clusterrolebinding.yml
+++ b/apps/goldpinger/manifests/ClusterRoleBinding-goldpinger-clusterrolebinding.yml
@@ -1,0 +1,18 @@
+---
+# Source: goldpinger/templates/clusterrolebinding.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: goldpinger-clusterrolebinding
+  labels:
+    app.kubernetes.io/name: goldpinger
+    app.kubernetes.io/instance: goldpinger
+    app.kubernetes.io/managed-by: Helm
+subjects:
+  - kind: ServiceAccount
+    name: goldpinger
+    namespace: goldpinger
+roleRef:
+  kind: ClusterRole
+  name: goldpinger-clusterrole
+  apiGroup: rbac.authorization.k8s.io

--- a/apps/goldpinger/manifests/ConfigMap-goldpinger-zap.yml
+++ b/apps/goldpinger/manifests/ConfigMap-goldpinger-zap.yml
@@ -1,0 +1,12 @@
+---
+# Source: goldpinger/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: goldpinger-zap
+  labels:
+    app.kubernetes.io/name: goldpinger
+    app.kubernetes.io/instance: goldpinger
+    app.kubernetes.io/managed-by: Helm
+data:
+  zap.json: "{\n  \"level\": \"info\",\n  \"encoding\": \"json\",\n  \"outputPaths\": [\n      \"stdout\"\n  ],\n  \"errorOutputPaths\": [\n      \"stderr\"\n  ],\n  \"initialFields\": {\n  },\n  \"encoderConfig\": {\n      \"messageKey\": \"message\",\n      \"levelKey\": \"level\",\n      \"levelEncoder\": \"lowercase\",\n      \"timeKey\": \"ts\",\n      \"timeEncoder\": \"ISO8601\",\n      \"callerKey\": \"caller\",\n      \"callerEncoder\": \"Short\"\n  }\n}\n"

--- a/apps/goldpinger/manifests/DaemonSet-goldpinger.yml
+++ b/apps/goldpinger/manifests/DaemonSet-goldpinger.yml
@@ -1,0 +1,85 @@
+---
+# Source: goldpinger/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: goldpinger
+  labels:
+    app.kubernetes.io/name: goldpinger
+    app.kubernetes.io/instance: goldpinger
+    app.kubernetes.io/managed-by: Helm
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 25%
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: goldpinger
+      app.kubernetes.io/instance: goldpinger
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: goldpinger
+        app.kubernetes.io/instance: goldpinger
+    spec:
+      priorityClassName: node-observability
+      serviceAccountName: goldpinger
+      containers:
+        - name: goldpinger-daemon
+          image: "bloomberg/goldpinger:3.11.0"
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: zap
+              mountPath: /config
+          env:
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST
+              value: "0.0.0.0"
+            - name: PORT
+              value: "8080"
+            - name: LABEL_SELECTOR
+              value: "app.kubernetes.io/name=goldpinger"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            limits:
+              memory: 64Mi
+            requests:
+              cpu: 10m
+              memory: 64Mi
+      volumes:
+        - name: zap
+          configMap:
+            name: goldpinger-zap
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
+      securityContext:
+        fsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault

--- a/apps/goldpinger/manifests/Service-goldpinger.yml
+++ b/apps/goldpinger/manifests/Service-goldpinger.yml
@@ -1,0 +1,20 @@
+---
+# Source: goldpinger/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: goldpinger
+  labels:
+    app.kubernetes.io/name: goldpinger
+    app.kubernetes.io/instance: goldpinger
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8081
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: goldpinger
+    app.kubernetes.io/instance: goldpinger

--- a/apps/goldpinger/manifests/ServiceAccount-goldpinger.yml
+++ b/apps/goldpinger/manifests/ServiceAccount-goldpinger.yml
@@ -1,0 +1,10 @@
+---
+# Source: goldpinger/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: goldpinger
+  labels:
+    app.kubernetes.io/name: goldpinger
+    app.kubernetes.io/instance: goldpinger
+    app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
Enable CI rendering of goldpinger helm chart and make sure CI runs on changes to Makefiles to, so that we do not need to verify Makefile changes locally.