### PR TITLE
v=5 is considered trace, 1-4 is various level of debug and 0 is errors and key event logging. Setting it to v=0

### DIFF
--- a/apps/velero/external-snapshotter/kustomization.yaml
+++ b/apps/velero/external-snapshotter/kustomization.yaml
@@ -8,3 +8,11 @@ resources: # crds.yaml is intentionally left out
 images:
   - name: registry.k8s.io/sig-storage/snapshot-controller
     newTag: v8.5.0
+patches:
+  - target:
+      kind: Deployment
+      name: snapshot-controller
+    patch: |-
+      - op: replace
+        path: "/spec/template/spec/containers/0/args/0"
+        value: "--v=0"

--- a/apps/velero/external-snapshotter/manifests/Deployment-snapshot-controller.yml
+++ b/apps/velero/external-snapshotter/manifests/Deployment-snapshot-controller.yml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - args:
-            - --v=5
+            - --v=0
             - --leader-election=true
           image: registry.k8s.io/sig-storage/snapshot-controller:v8.5.0
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Change log level for external-snapshot-controller via a global patch (not to be confused with dynamic overlay patches).

5 -> trace logging
1-4 -> various debug levels
0 -> standard error and key event logging

Every 15 minutes we get roughly ~250k log entries. Maybe that is just too chatty.