### PR TITLE
Bump arc-runners ephemeral work volume to 50Gi

### DIFF
--- a/apps/github-arc-runners/release.yaml
+++ b/apps/github-arc-runners/release.yaml
@@ -65,4 +65,4 @@ spec:
                   storageClassName: csi-gp3
                   resources:
                     requests:
-                      storage: 1Gi
+                      storage: 50Gi


### PR DESCRIPTION
Volumes are ephemeral (deleted when job finishes), so cost-per-run is extremely low regardless of size. gp3 is $0.08/GB month, a 50 GiB volume existing for 30 min costs < $0.01.