### PR TITLE
Enforce restrict service type policy

### DIFF
--- a/apps/kyverno/policies/operational/restrict-service-types.yaml
+++ b/apps/kyverno/policies/operational/restrict-service-types.yaml
@@ -10,7 +10,7 @@ metadata:
     policies.kyverno.io/description: >-
       Services of type LoadBalancer and NodePort are not allowed. This prevents the creation of LoadBalancer and NodePort Services which can lead to unintended exposure and costs.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: Enforce
   emitWarning: true
   background: true
   rules:


### PR DESCRIPTION
We currently have no in use service types NodePort or LoadBalancer that are in actual use in Hellman. So flipping this to Enforce make sense to block incoming.