### PR TITLE
Stop validation of Traefik variants serivce type nodeport, since postBuildVariableSubst is breaking validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,4 @@ repos:
           - -schema-location
           - "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
         files: ^apps/.*
+        exclude: ^apps/traefik-.*-variant/manifests/Service-traefik-.*-variant.yml$ # excluded due to nodePort values that are substituted by flux and not valid integers


### PR DESCRIPTION
Exclude kubeconform validation on Traefik helm chart rendered services, since they fail

```
apps/traefik-green-variant/manifests/Service-traefik-green-variant.yml - Service traefik-green-variant is invalid: problem validating schema. Check JSON formatting: jsonschema validation failed with 'https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/service-v1.json#' - at '/spec/ports/0/nodePort': got string, want null or integer - at '/spec/ports/1/nodePort': got string, want null or integer
apps/traefik-blue-variant/manifests/Service-traefik-blue-variant.yml - Service traefik-blue-variant is invalid: problem validating schema. Check JSON formatting: jsonschema validation failed with 'https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/service-v1.json#' - at '/spec/ports/0/nodePort': got string, want null or integer - at '/spec/ports/1/nodePort': got string, want null or integer
```