### PR TITLE
Remove AWS LB controller namespace scope, since we now limits service type loadbalancers

### DIFF
--- a/apps/aws-lb-controller/manifests/Deployment-aws-lb-controller-aws-load-balancer-controller.yml
+++ b/apps/aws-lb-controller/manifests/Deployment-aws-lb-controller-aws-load-balancer-controller.yml
@@ -40,7 +40,6 @@ spec:
             - --ingress-class=alb
             - --aws-region=${flux_aws_region}
             - --aws-vpc-id=${flux_vpc_id}
-            - --watch-namespace=aws-lb-controller
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/apps/aws-lb-controller/release.yaml
+++ b/apps/aws-lb-controller/release.yaml
@@ -33,5 +33,4 @@ spec:
         memory: 64Mi
       limits:
         memory: 64Mi
-    watchNamespace: aws-lb-controller
     vpcId: ${flux_vpc_id}


### PR DESCRIPTION
We no longer need to only watch in this namespace, since we block service type loadbalancers in all namespaces other than Traefik variant ones. This means that TargetGroupBinding resources can eventually be watched by this controller in Traefik namespaces and since TargetGroupBinding is namespaces and referencing services, watching a single namespace wont work.

For reference TargetGroupBinding is used for registering and deregistering nodes where Traefik is running in stead of all nodes as we do now.