### PR TITLE
add needed secret mappings in atlantis to support Grafana access to 1password

### DIFF
--- a/apps/atlantis/externalsecret-atlantis-environment.yaml
+++ b/apps/atlantis/externalsecret-atlantis-environment.yaml
@@ -208,6 +208,10 @@ spec:
       remoteRef:
         key: 1Password Connect
         property: prod_atlantis_token
+    - secretKey: PRODUCTION_ONEPASSWORD_TOKEN_FOR_GRAFANA
+      remoteRef:
+        key: 1Password Connect
+        property: prod_grafana_token
     - secretKey: STAGING_ONEPASSWORD_CREDENTIALS_JSON
       remoteRef:
         key: 1Password Connect
@@ -216,6 +220,10 @@ spec:
       remoteRef:
         key: 1Password Connect
         property: nonprod_atlantis_token
+    - secretKey: STAGING_ONEPASSWORD_TOKEN_FOR_GRAFANA
+      remoteRef:
+        key: 1Password Connect
+        property: nonprod_grafana_token
     - secretKey: SHARED_docker_hub_username
       remoteRef:
         key: Docker Cloud


### PR DESCRIPTION
This pull request adds new secrets for Grafana tokens to the Atlantis environment configuration. These changes ensure that both production and staging environments have access to their respective Grafana tokens stored in 1Password.

**Secrets management updates:**

* Added a new secret `PRODUCTION_ONEPASSWORD_TOKEN_FOR_GRAFANA` to reference the `prod_grafana_token` property from 1Password for the production environment.
* Added a new secret `STAGING_ONEPASSWORD_TOKEN_FOR_GRAFANA` to reference the `nonprod_grafana_token` property from 1Password for the staging environment.