### PR TITLE
Drop unused STAGING_* secrets from Atlantis pod env

### DIFF
--- a/apps/atlantis/manifests/StatefulSet-atlantis.yml
+++ b/apps/atlantis/manifests/StatefulSet-atlantis.yml
@@ -247,41 +247,6 @@ spec:
                 secretKeyRef:
                   name: atlantis-environment
                   key: STAGING_AWS_SECRET_ACCESS_KEY
-            - name: STAGING_GRAFANA_AGENT_API_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: atlantis-environment
-                  key: STAGING_GRAFANA_AGENT_API_TOKEN
-            - name: STAGING_GRAFANA_AGENT_LOKI_URL
-              valueFrom:
-                secretKeyRef:
-                  name: atlantis-environment
-                  key: STAGING_GRAFANA_AGENT_LOKI_URL
-            - name: STAGING_GRAFANA_AGENT_LOKI_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: atlantis-environment
-                  key: STAGING_GRAFANA_AGENT_LOKI_USERNAME
-            - name: STAGING_GRAFANA_AGENT_PROMETHEUS_URL
-              valueFrom:
-                secretKeyRef:
-                  name: atlantis-environment
-                  key: STAGING_GRAFANA_AGENT_PROMETHEUS_URL
-            - name: STAGING_GRAFANA_AGENT_PROMETHEUS_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: atlantis-environment
-                  key: STAGING_GRAFANA_AGENT_PROMETHEUS_USERNAME
-            - name: STAGING_GRAFANA_AGENT_TEMPO_URL
-              valueFrom:
-                secretKeyRef:
-                  name: atlantis-environment
-                  key: STAGING_GRAFANA_AGENT_TEMPO_URL
-            - name: STAGING_GRAFANA_AGENT_TEMPO_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: atlantis-environment
-                  key: STAGING_GRAFANA_AGENT_TEMPO_USERNAME
             - name: DS_SSU_VM_ENDPOINT
               valueFrom:
                 secretKeyRef:
@@ -397,11 +362,6 @@ spec:
                 secretKeyRef:
                   name: atlantis-environment
                   key: STAGING_falco_slack_alert_webhook_url
-            - name: STAGING_falco_stream_webhook_url
-              valueFrom:
-                secretKeyRef:
-                  name: atlantis-environment
-                  key: STAGING_falco_stream_webhook_url
             - name: PRODUCTION_falco_slack_alert_webhook_url
               valueFrom:
                 secretKeyRef:

--- a/apps/atlantis/release.yaml
+++ b/apps/atlantis/release.yaml
@@ -179,34 +179,6 @@ spec:
         secretKeyRef:
           key: STAGING_AWS_SECRET_ACCESS_KEY
           name: atlantis-environment
-      - name: STAGING_GRAFANA_AGENT_API_TOKEN
-        secretKeyRef:
-          key: STAGING_GRAFANA_AGENT_API_TOKEN
-          name: atlantis-environment
-      - name: STAGING_GRAFANA_AGENT_LOKI_URL
-        secretKeyRef:
-          key: STAGING_GRAFANA_AGENT_LOKI_URL
-          name: atlantis-environment
-      - name: STAGING_GRAFANA_AGENT_LOKI_USERNAME
-        secretKeyRef:
-          key: STAGING_GRAFANA_AGENT_LOKI_USERNAME
-          name: atlantis-environment
-      - name: STAGING_GRAFANA_AGENT_PROMETHEUS_URL
-        secretKeyRef:
-          key: STAGING_GRAFANA_AGENT_PROMETHEUS_URL
-          name: atlantis-environment
-      - name: STAGING_GRAFANA_AGENT_PROMETHEUS_USERNAME
-        secretKeyRef:
-          key: STAGING_GRAFANA_AGENT_PROMETHEUS_USERNAME
-          name: atlantis-environment
-      - name: STAGING_GRAFANA_AGENT_TEMPO_URL
-        secretKeyRef:
-          key: STAGING_GRAFANA_AGENT_TEMPO_URL
-          name: atlantis-environment
-      - name: STAGING_GRAFANA_AGENT_TEMPO_USERNAME
-        secretKeyRef:
-          key: STAGING_GRAFANA_AGENT_TEMPO_USERNAME
-          name: atlantis-environment
       - name: DS_SSU_VM_ENDPOINT
         secretKeyRef:
           key: DS_SSU_VM_ENDPOINT
@@ -298,10 +270,6 @@ spec:
       - name: STAGING_falco_slack_alert_webhook_url
         secretKeyRef:
           key: STAGING_falco_slack_alert_webhook_url
-          name: atlantis-environment
-      - name: STAGING_falco_stream_webhook_url
-        secretKeyRef:
-          key: STAGING_falco_stream_webhook_url
           name: atlantis-environment
       - name: PRODUCTION_falco_slack_alert_webhook_url
         secretKeyRef:


### PR DESCRIPTION
This pull request removes several unused or unnecessary environment variables from the `apps/atlantis/release.yaml` configuration. The main focus is on cleaning up secrets related to Grafana Agent and Falco integrations.

Configuration cleanup:

* Removed all staging Grafana Agent-related environment variables, including tokens and URLs for Loki, Prometheus, and Tempo, from the Kubernetes deployment spec.
* Removed the `STAGING_falco_stream_webhook_url` environment variable from the deployment spec.