### PR TITLE
HelmRepository for OCI have no status, so we change it to OCIRepository resource

### DIFF
--- a/apps/github-arc-runners/release.yaml
+++ b/apps/github-arc-runners/release.yaml
@@ -12,14 +12,9 @@ spec:
       namespace: arc-systems
     - name: external-secrets
       namespace: external-secrets
-  chart:
-    spec:
-      chart: gha-runner-scale-set
-      version: 0.14.1
-      sourceRef:
-        kind: HelmRepository
-        name: arc
-        namespace: arc-runners
+  chartRef:
+    kind: OCIRepository
+    name: arc
   interval: 10m0s
   install:
     remediation:

--- a/apps/github-arc-runners/sources.yaml
+++ b/apps/github-arc-runners/sources.yaml
@@ -1,9 +1,10 @@
 apiVersion: source.toolkit.fluxcd.io/v1
-kind: HelmRepository
+kind: OCIRepository
 metadata:
   name: arc
   namespace: arc-runners
 spec:
   interval: 1h0m0s
-  type: oci
   url: oci://ghcr.io/actions/actions-runner-controller-charts
+  ref:
+    tag: "0.14.1"


### PR DESCRIPTION
Eventhough flux cli will show a status for HelmRepository of type OCI, it is not really a thing on the Kubernetes object. Having a status can be beneficial for testing or monitoring purpose.

<img width="594" height="68" alt="image" src="https://github.com/user-attachments/assets/9ebb7e2e-67cf-4ad9-bf5b-54a3ce7bf75e" />

<img width="594" height="354" alt="image" src="https://github.com/user-attachments/assets/688062c3-4da1-46a1-9bdb-51f4a27b46d1" />
