### PR TITLE
Revert "HelmRepository for OCI have no status, so we change it to OCIRepository resource"

### DIFF
--- a/apps/github-arc-runners/release.yaml
+++ b/apps/github-arc-runners/release.yaml
@@ -12,9 +12,14 @@ spec:
       namespace: arc-systems
     - name: external-secrets
       namespace: external-secrets
-  chartRef:
-    kind: OCIRepository
-    name: arc
+  chart:
+    spec:
+      chart: gha-runner-scale-set
+      version: 0.14.1
+      sourceRef:
+        kind: HelmRepository
+        name: arc
+        namespace: arc-runners
   interval: 10m0s
   install:
     remediation:

--- a/apps/github-arc-runners/sources.yaml
+++ b/apps/github-arc-runners/sources.yaml
@@ -1,10 +1,9 @@
 apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
+kind: HelmRepository
 metadata:
   name: arc
   namespace: arc-runners
 spec:
   interval: 1h0m0s
+  type: oci
   url: oci://ghcr.io/actions/actions-runner-controller-charts
-  ref:
-    tag: "0.14.1"


### PR DESCRIPTION
Reverts dfds/platform-apps#572

Apparently we have more than one implementation of this arc runner.