### PR TITLE
Increase memory requests and limits for aws-lb-controller due to being OOMKilled in prod

### DIFF
--- a/apps/aws-lb-controller/manifests/Deployment-aws-lb-controller-aws-load-balancer-controller.yml
+++ b/apps/aws-lb-controller/manifests/Deployment-aws-lb-controller-aws-load-balancer-controller.yml
@@ -59,10 +59,10 @@ spec:
               protocol: TCP
           resources:
             limits:
-              memory: 64Mi
+              memory: 128Mi
             requests:
               cpu: 100m
-              memory: 64Mi
+              memory: 128Mi
           livenessProbe:
             failureThreshold: 2
             httpGet:

--- a/apps/aws-lb-controller/release.yaml
+++ b/apps/aws-lb-controller/release.yaml
@@ -30,7 +30,7 @@ spec:
     resources:
       requests:
         cpu: 100m
-        memory: 64Mi
+        memory: 128Mi
       limits:
-        memory: 64Mi
+        memory: 128Mi
     vpcId: ${flux_vpc_id}


### PR DESCRIPTION
This pull request increases the memory allocation for the AWS Load Balancer Controller. The memory requests and limits have both been doubled from 64Mi to 128Mi in the `release.yaml` configuration file.

* Increased `memory` requests and limits for the controller from 64Mi to 128Mi in `apps/aws-lb-controller/release.yaml` to provide more resources for the application.