### PR TITLE
Add/alb/targetgroupsbindings

### DIFF
--- a/apps/traefik-green-variant/kustomization.yaml
+++ b/apps/traefik-green-variant/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - namespace.yaml
   - sources.yaml
   - release.yaml
+  - targetgroupbindings.yaml

--- a/apps/traefik-green-variant/manifests/Service-traefik-green-variant.yml
+++ b/apps/traefik-green-variant/manifests/Service-traefik-green-variant.yml
@@ -12,8 +12,7 @@ metadata:
     scrape-service-metrics: "true"
   annotations:
 spec:
-  type: NodePort
-  externalTrafficPolicy: Cluster
+  type: ClusterIP
   selector:
     app.kubernetes.io/name: traefik
     app.kubernetes.io/instance: traefik-green-variant-traefik-green-variant
@@ -22,9 +21,7 @@ spec:
       name: traefik
       targetPort: traefik
       protocol: TCP
-      nodePort: ${flux_traefik_green_target_admin_port}
     - port: 80
       name: web
       targetPort: web
       protocol: TCP
-      nodePort: ${flux_traefik_green_target_http_port}

--- a/apps/traefik-green-variant/namespace.yaml
+++ b/apps/traefik-green-variant/namespace.yaml
@@ -5,3 +5,4 @@ metadata:
   name: traefik-green-variant
   labels:
     pod-security.kubernetes.io/enforce: baseline
+    elbv2.k8s.aws/pod-readiness-gate-inject: enabled

--- a/apps/traefik-green-variant/release.yaml
+++ b/apps/traefik-green-variant/release.yaml
@@ -65,11 +65,9 @@ spec:
       traefik:
         expose:
           default: true
-        nodePort: ${flux_traefik_green_target_admin_port}
       web:
         forwardedHeaders:
           insecure: true
-        nodePort: ${flux_traefik_green_target_http_port}
       websecure:
         expose:
           default: false
@@ -93,4 +91,4 @@ spec:
         scrape-service-metrics: "true"
       spec:
         externalTrafficPolicy: Local
-      type: NodePort
+      type: ClusterIP

--- a/apps/traefik-green-variant/release.yaml
+++ b/apps/traefik-green-variant/release.yaml
@@ -92,5 +92,5 @@ spec:
       labels:
         scrape-service-metrics: "true"
       spec:
-        externalTrafficPolicy: Cluster
+        externalTrafficPolicy: Local
       type: NodePort

--- a/apps/traefik-green-variant/release.yaml
+++ b/apps/traefik-green-variant/release.yaml
@@ -89,6 +89,4 @@ spec:
       enabled: true
       labels:
         scrape-service-metrics: "true"
-      spec:
-        externalTrafficPolicy: Local
       type: ClusterIP

--- a/apps/traefik-green-variant/targetgroupbindings.yaml
+++ b/apps/traefik-green-variant/targetgroupbindings.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: elbv2.k8s.aws/v1beta1
+kind: TargetGroupBinding
+metadata:
+  name: alb-anon
+  namespace: traefik-green-variant
+spec:
+  serviceRef:
+    name: traefik-green-variant
+    port: web
+  targetGroupARN: ${flux_traefik_anon_target_group_arn}
+  targetType: ip
+
+---
+apiVersion: elbv2.k8s.aws/v1beta1
+kind: TargetGroupBinding
+metadata:
+  name: alb-auth
+  namespace: traefik-green-variant
+spec:
+  serviceRef:
+    name: traefik-green-variant
+    port: web
+  targetGroupARN: ${flux_traefik_auth_target_group_arn}
+  targetType: ip

--- a/apps/traefik-green-variant/targetgroupbindings.yaml
+++ b/apps/traefik-green-variant/targetgroupbindings.yaml
@@ -4,6 +4,8 @@ kind: TargetGroupBinding
 metadata:
   name: alb-anon
   namespace: traefik-green-variant
+  annotations:
+    kustomize.toolkit.fluxcd.io/force: enabled
 spec:
   serviceRef:
     name: traefik-green-variant
@@ -17,6 +19,8 @@ kind: TargetGroupBinding
 metadata:
   name: alb-auth
   namespace: traefik-green-variant
+  annotations:
+    kustomize.toolkit.fluxcd.io/force: enabled
 spec:
   serviceRef:
     name: traefik-green-variant

--- a/apps/traefik-green-variant/targetgroupbindings.yaml
+++ b/apps/traefik-green-variant/targetgroupbindings.yaml
@@ -8,7 +8,7 @@ spec:
   serviceRef:
     name: traefik-green-variant
     port: web
-  targetGroupARN: ${flux_traefik_anon_target_group_arn}
+  targetGroupARN: ${flux_alb_target_group_arn}
   targetType: ip
 
 ---
@@ -21,5 +21,5 @@ spec:
   serviceRef:
     name: traefik-green-variant
     port: web
-  targetGroupARN: ${flux_traefik_auth_target_group_arn}
+  targetGroupARN: ${flux_alb_auth_target_group_arn}
   targetType: ip


### PR DESCRIPTION
Below is the introduction copied from this [PR](https://github.com/dfds/infrastructure-modules/pull/2370) in infrastructure-modules:
In our current setup all nodes are target for the load balancers in place exposing two nodeports each. The targetgroup registration is happening through an autoscalinggroup attachment. This makes all nodes go through a registration and deregistration process and adding on top of this all requests are very, very likely to make an extra network jump from the node to a node that actually has Traefik running.

Things done:
* change service type from nodeport to clusterip for Traefik green variant
* add targetgroupbinding for registering Traefik green pods to the correct targetgroup in AWS. Note that we are adding kustomize label to make sure the is overwritten because spec.targetGroupArn is immutable
* add readiness probe gate label to Traefik green namespace to ensure that status ready for pods is only set if the pod is a healthy registered target for the targetgroup in AWS see https://kubernetes-sigs.github.io/aws-load-balancer-controller/v3.4/deploy/pod_readiness_gate/ for docs