### PR TITLE
grafana agent memory request and limit set to be the same to guarantee memory resource allocations

### DIFF
--- a/apps/grafana/manifests/StatefulSet-grafana-k8s-monitoring-alloy.yml
+++ b/apps/grafana/manifests/StatefulSet-grafana-k8s-monitoring-alloy.yml
@@ -90,9 +90,9 @@ spec:
             timeoutSeconds: 1
           resources:
             limits:
-              memory: ${flux_grafana_agent_resource_memory_limit}
+              memory: ${flux_grafana_agent_resource_memory}
             requests:
-              memory: ${flux_grafana_agent_resource_memory_request}
+              memory: ${flux_grafana_agent_resource_memory}
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/apps/grafana/release.yaml
+++ b/apps/grafana/release.yaml
@@ -94,9 +94,9 @@ spec:
               name: agent-wal
         resources:
           requests:
-            memory: ${flux_grafana_agent_resource_memory_request}
+            memory: ${flux_grafana_agent_resource_memory}
           limits:
-            memory: ${flux_grafana_agent_resource_memory_limit}
+            memory: ${flux_grafana_agent_resource_memory}
       controller:
         replicas: ${flux_grafana_agent_replicas}
         priorityClassName: cluster-observability


### PR DESCRIPTION
* Updated `apps/grafana/release.yaml` to use `${flux_grafana_agent_resource_memory}` for both memory requests and limits, replacing the previous use of separate variables.

related https://github.com/dfds/infrastructure-modules/pull/2369/changes