### PR TITLE
Update workflow references to use specific version tags for consistency

### DIFF
--- a/.github/workflows/autorelease.yaml
+++ b/.github/workflows/autorelease.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   shared:
-    uses: dfds/shared-workflows/.github/workflows/automation-auto-release.yml@master
+    uses: dfds/shared-workflows/.github/workflows/automation-auto-release.yml@v2.0.1
     # Note, make sure to use `secrets: inherit` if utilizing the organizational secret `GH_RELEASE`
     secrets: inherit
 

--- a/.github/workflows/enforce-pr-labels.yaml
+++ b/.github/workflows/enforce-pr-labels.yaml
@@ -3,8 +3,8 @@ name: Enforce PR labels
 on:
   pull_request:
     types: [labeled, unlabeled, opened, edited, synchronize]
-    branches: [ "master", "main" ]
+    branches: ["main"]
 
 jobs:
   shared:
-    uses: dfds/shared-workflows/.github/workflows/automation-enforce-release-labels.yml@master
+    uses: dfds/shared-workflows/.github/workflows/automation-enforce-release-labels.yml@v2.0.1


### PR DESCRIPTION
This pull request updates our GitHub Actions workflows to use a newer, versioned release of our shared workflows and ensures branch targeting consistency. The main improvements are increased stability and predictability for CI/CD automation.

**Workflow version updates:**

* Updated the `shared` job in `.github/workflows/autorelease.yaml` to use `automation-auto-release.yml@v2.0.1` instead of tracking `master`.
* Updated the `shared` job in `.github/workflows/enforce-pr-labels.yaml` to use `automation-enforce-release-labels.yml@v2.0.1` instead of tracking `master`.

**Branch targeting:**

* Changed the `enforce-pr-labels.yaml` workflow to only run on the `main` branch, removing `master` from the list.