### PR TITLE
Update externalsecret-atlantis-environment.yaml

### DIFF
--- a/apps/atlantis/externalsecret-atlantis-environment.yaml
+++ b/apps/atlantis/externalsecret-atlantis-environment.yaml
@@ -276,7 +276,7 @@ spec:
     - secretKey: STAGING_falco_slack_alert_webhook_url
       remoteRef:
         key: Slack dfds.slack.com webhooks
-        property: "#falco-alerts-staging-hellman (The All-Seeing Eye)"
+        property: "#falco-alerts-staging-hellman (Staging Alert Bot)"
     - secretKey: STAGING_falco_stream_webhook_url
       remoteRef:
         key: Slack dfds.slack.com webhooks


### PR DESCRIPTION
Falco always had a false diff in staging due to mismatch of webhooks used. This fixes that