### PR TITLE
revert migration of grafana CRDs to flux

### DIFF
--- a/apps/grafana/kustomization.yaml
+++ b/apps/grafana/kustomization.yaml
@@ -1,7 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - crds.yaml
   - namespace.yaml
   - serviceaccount.yaml
   - secretstore-ssm.yaml

--- a/apps/grafana/manifests/ConfigMap-grafana-k8s-monitoring-alloy.yml
+++ b/apps/grafana/manifests/ConfigMap-grafana-k8s-monitoring-alloy.yml
@@ -731,4 +731,4 @@ data:
   k8s-monitoring-build-info-metric.prom: |
     # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
     # TYPE grafana_kubernetes_monitoring_build_info gauge
-    grafana_kubernetes_monitoring_build_info{version="1.6.52", namespace="grafana", metrics="enabled,alloy,kube-state-metrics,node-exporter,kubelet,kubeletResource,cadvisor", logs="enabled,events,pod_logs,journal,extraConfig", traces="enabled", deployments="kube-state-metrics,prometheus-node-exporter"} 1
+    grafana_kubernetes_monitoring_build_info{version="1.6.52", namespace="grafana", metrics="enabled,alloy,kube-state-metrics,node-exporter,kubelet,kubeletResource,cadvisor", logs="enabled,events,pod_logs,journal,extraConfig", traces="enabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds"} 1

--- a/apps/grafana/release.yaml
+++ b/apps/grafana/release.yaml
@@ -16,7 +16,6 @@ spec:
         namespace: grafana
   interval: 1m0s
   install:
-    crds: Skip
     remediation:
       retries: 3
   values:
@@ -250,7 +249,7 @@ spec:
           maxUnavailable: 25%
 
     prometheus-operator-crds:
-      enabled: false
+      enabled: true
     extraObjects:
       - apiVersion: monitoring.coreos.com/v1
         kind: ServiceMonitor


### PR DESCRIPTION
Reverting most of the changes of this PR https://github.com/dfds/platform-apps/pull/581 because it has the unintended side-effect of recreating the Prometheus CRDs. This causes destructive behavior of existing resources that use these CRDs 

CRD management improvements:
* Removed the manual inclusion of `crds.yaml` from the `kustomization.yaml`, so CRDs are no longer managed separately in Kustomize.
* Removed the `crds: Skip` directive from the Helm release install configuration, allowing Helm to handle CRD installation.
* Enabled the `prometheus-operator-crds` Helm chart value, ensuring that Prometheus Operator CRDs are installed as part of the release.