### PR TITLE
Update role ARN in ServiceAccount for dynamic cluster name

### DIFF
--- a/apps/github-arc-runners/serviceaccount-eso.yaml
+++ b/apps/github-arc-runners/serviceaccount-eso.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::${flux_workload_account_id}:role/ssm-secrets-for-kubernetes
+    eks.amazonaws.com/role-arn: arn:aws:iam::${flux_workload_account_id}:role/ssm-secrets-for-kubernetes-${flux_cluster_name}
     eks.amazonaws.com/sts-regional-endpoints: "true"
   name: ssm-secrets
   namespace: arc-runners


### PR DESCRIPTION
Fixing a bug in arc-runners where it is not able to assume a role in order to use IRSA with SSM