### PR TITLE
Add Traefik preStop hook and increase terminationGracePeriodSeconds

### DIFF
--- a/apps/traefik-blue-variant/manifests/Deployment-traefik-blue-variant.yml
+++ b/apps/traefik-blue-variant/manifests/Deployment-traefik-blue-variant.yml
@@ -35,7 +35,7 @@ spec:
     spec:
       serviceAccountName: traefik-blue-variant
       automountServiceAccountToken: true
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 320
       hostNetwork: false
       containers:
         - image: docker.io/traefik:v3.6.2
@@ -68,6 +68,9 @@ spec:
             successThreshold: 1
             timeoutSeconds: 2
           lifecycle:
+            preStop:
+              sleep:
+                seconds: 300
           ports:
             - name: metrics
               containerPort: 9100

--- a/apps/traefik-blue-variant/release.yaml
+++ b/apps/traefik-blue-variant/release.yaml
@@ -26,6 +26,11 @@ spec:
   values:
     deployment:
       replicas: 3
+      terminationGracePeriodSeconds: 320 # needs to be higher than lifecycle.prestop period
+      lifecycle:
+        preStop:
+          sleep:
+            seconds: 300 # has be on the order of targetgroup derigstration delay 300s and needs to be lower than terminationGracePeriodSeconds
     gateway:
       listeners:
         web:

--- a/apps/traefik-green-variant/manifests/Deployment-traefik-green-variant.yml
+++ b/apps/traefik-green-variant/manifests/Deployment-traefik-green-variant.yml
@@ -35,7 +35,7 @@ spec:
     spec:
       serviceAccountName: traefik-green-variant
       automountServiceAccountToken: true
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 320
       hostNetwork: false
       containers:
         - image: docker.io/traefik:v3.6.2
@@ -68,6 +68,9 @@ spec:
             successThreshold: 1
             timeoutSeconds: 2
           lifecycle:
+            preStop:
+              sleep:
+                seconds: 300
           ports:
             - name: metrics
               containerPort: 9100

--- a/apps/traefik-green-variant/release.yaml
+++ b/apps/traefik-green-variant/release.yaml
@@ -26,6 +26,11 @@ spec:
   values:
     deployment:
       replicas: 3
+      terminationGracePeriodSeconds: 320 # needs to be higher than lifecycle.prestop period
+      lifecycle:
+        preStop:
+          sleep:
+            seconds: 300 # has be on the order of targetgroup derigstration delay 300s and needs to be lower than terminationGracePeriodSeconds
     gateway:
       listeners:
         web:


### PR DESCRIPTION
We are most likely currently dropping requests because Traefik Pods can terminate as soon a new Traefik Pod is Ready, so to protect in flight requests we need to implement preStop hook. Our current TargetGroup deregistration delay is the default of 300 seconds see [here](https://github.com/dfds/infrastructure-modules/blob/464cece7a6560fc4ab2383cc6653407f5771837e/_sub/compute/eks-alb/main.tf#L30) as an example.

* Add preStop hook to sleep for 300 seconds for both Traefik Deployments
* Increase terminationGracePeriodSeconds to accommodate for the increased Termination delay 