### PR TITLE
Added topology spread contraint, so that Traefik instances prefer to run on different nodes

### DIFF
--- a/apps/traefik-blue-variant/manifests/Deployment-traefik-blue-variant.yml
+++ b/apps/traefik-blue-variant/manifests/Deployment-traefik-blue-variant.yml
@@ -144,3 +144,10 @@ spec:
         runAsGroup: 65532
         runAsNonRoot: true
         runAsUser: 65532
+      topologySpreadConstraints:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/instance: traefik-blue-variant-traefik-blue-variant
+          maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule

--- a/apps/traefik-blue-variant/release.yaml
+++ b/apps/traefik-blue-variant/release.yaml
@@ -31,6 +31,13 @@ spec:
         preStop:
           sleep:
             seconds: 300 # has be on the order of targetgroup derigstration delay 300s and needs to be lower than terminationGracePeriodSeconds
+    topologySpreadConstraints:
+     - labelSelector:
+         matchLabels:
+           app.kubernetes.io/instance: traefik-blue-variant-traefik-blue-variant
+       maxSkew: 1
+       topologyKey: kubernetes.io/hostname
+       whenUnsatisfiable: DoNotSchedule
     gateway:
       listeners:
         web:

--- a/apps/traefik-green-variant/manifests/Deployment-traefik-green-variant.yml
+++ b/apps/traefik-green-variant/manifests/Deployment-traefik-green-variant.yml
@@ -144,3 +144,10 @@ spec:
         runAsGroup: 65532
         runAsNonRoot: true
         runAsUser: 65532
+      topologySpreadConstraints:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/instance: traefik-green-variant-traefik-green-variant
+          maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule

--- a/apps/traefik-green-variant/release.yaml
+++ b/apps/traefik-green-variant/release.yaml
@@ -31,6 +31,13 @@ spec:
         preStop:
           sleep:
             seconds: 300 # has be on the order of targetgroup derigstration delay 300s and needs to be lower than terminationGracePeriodSeconds
+    topologySpreadConstraints:
+     - labelSelector:
+         matchLabels:
+           app.kubernetes.io/instance: traefik-green-variant-traefik-green-variant
+       maxSkew: 1
+       topologyKey: kubernetes.io/hostname
+       whenUnsatisfiable: DoNotSchedule
     gateway:
       listeners:
         web:


### PR DESCRIPTION
Our Traefik setup is currently edge case fragile if the mix of Traefik Pods lands on the same node and we loose that node. This prevents all Traefik Pods to land on the same node, but allows if the condition cannot be meet a skew of 1, so that in a freak scenario where we only have one node two Traefik Pods can run on the same node.

* Implement [Pod topologySpreadConstraint](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) (yes that is my favorite word of all time) for Traefik blue and green to prevent all Traefik Pods can be scheduled on the same node.