### PR TITLE
With preStop fo 300s timeout of the HelmRelease needs to reflect that too

### DIFF
--- a/apps/traefik-blue-variant/manifests/Deployment-traefik-blue-variant.yml
+++ b/apps/traefik-blue-variant/manifests/Deployment-traefik-blue-variant.yml
@@ -150,4 +150,4 @@ spec:
               app.kubernetes.io/instance: traefik-blue-variant-traefik-blue-variant
           maxSkew: 1
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: DoNotSchedule
+          whenUnsatisfiable: ScheduleAnyway

--- a/apps/traefik-blue-variant/release.yaml
+++ b/apps/traefik-blue-variant/release.yaml
@@ -19,6 +19,7 @@ spec:
         name: traefik
         namespace: traefik-blue-variant
   interval: 1m0s
+  timeout: 10m
   install:
     crds: Skip
     remediation:

--- a/apps/traefik-blue-variant/release.yaml
+++ b/apps/traefik-blue-variant/release.yaml
@@ -38,7 +38,7 @@ spec:
            app.kubernetes.io/instance: traefik-blue-variant-traefik-blue-variant
        maxSkew: 1
        topologyKey: kubernetes.io/hostname
-       whenUnsatisfiable: DoNotSchedule
+       whenUnsatisfiable: ScheduleAnyway
     gateway:
       listeners:
         web:

--- a/apps/traefik-green-variant/manifests/Deployment-traefik-green-variant.yml
+++ b/apps/traefik-green-variant/manifests/Deployment-traefik-green-variant.yml
@@ -150,4 +150,4 @@ spec:
               app.kubernetes.io/instance: traefik-green-variant-traefik-green-variant
           maxSkew: 1
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: DoNotSchedule
+          whenUnsatisfiable: ScheduleAnyway

--- a/apps/traefik-green-variant/release.yaml
+++ b/apps/traefik-green-variant/release.yaml
@@ -19,6 +19,7 @@ spec:
         name: traefik
         namespace: traefik-green-variant
   interval: 1m0s
+  timeout: 10m
   install:
     crds: Skip
     remediation:

--- a/apps/traefik-green-variant/release.yaml
+++ b/apps/traefik-green-variant/release.yaml
@@ -38,7 +38,7 @@ spec:
            app.kubernetes.io/instance: traefik-green-variant-traefik-green-variant
        maxSkew: 1
        topologyKey: kubernetes.io/hostname
-       whenUnsatisfiable: DoNotSchedule
+       whenUnsatisfiable: ScheduleAnyway
     gateway:
       listeners:
         web:


### PR DESCRIPTION
We recently introduced preStop of 300s to match the AWS targetgroup deregistration delay of 300s, but this is also on order of the default timeout of the HelmRelease, hence we are increasing it from 5m30s (defualt) to 10m.

I also ended up adding ScheduleAnyway to combat blocked scheduling for small clusters.