### PR TITLE
Karpenter EC2NodeClass supports maxPods and kubeReserved directly in the spec

### DIFF
--- a/apps/karpenter-nodes/classes/al2023.yaml
+++ b/apps/karpenter-nodes/classes/al2023.yaml
@@ -28,6 +28,8 @@ spec:
     maxPods: 110
     kubeReserved:
       memory: 1465Mi # 255Mi + (11Mi * maxPods)
+    systemReserved:
+      memory: 200Mi
   userData: |
     MIME-Version: 1.0
     Content-Type: multipart/mixed; boundary="BOUNDARY"
@@ -92,6 +94,8 @@ spec:
     maxPods: 110
     kubeReserved:
       memory: 1465Mi # 255Mi + (11Mi * maxPods)
+    systemReserved:
+      memory: 200Mi
   userData: |
     MIME-Version: 1.0
     Content-Type: multipart/mixed; boundary="BOUNDARY"

--- a/apps/karpenter-nodes/classes/al2023.yaml
+++ b/apps/karpenter-nodes/classes/al2023.yaml
@@ -24,6 +24,10 @@ spec:
         karpenter.sh/discovery: "${flux_cluster_name}"
   detailedMonitoring: true
   associatePublicIPAddress: true
+  kubelet:
+    maxPods: 110
+    kubeReserved:
+      memory: 1465Mi # 255Mi + (11Mi * maxPods)
   userData: |
     MIME-Version: 1.0
     Content-Type: multipart/mixed; boundary="BOUNDARY"
@@ -33,9 +37,6 @@ spec:
 
     #!/bin/sh
     set -o xtrace
-
-    echo fs.inotify.max_user_watches=131072 | sudo tee -a /etc/sysctl.conf
-    sudo sysctl -p
 
     DOCKER_HUB_CREDS=$(aws ssm get-parameter --name /eks/${flux_cluster_name}/dockerhub --with-decrypt --query 'Parameter.Value' --output text)
     DOCKER_HUB_USER=$(echo "$DOCKER_HUB_CREDS" | jq .username)
@@ -57,14 +58,7 @@ spec:
     spec:
       kubelet:
         config:
-          maxPods: 110
-          registryPullQPS: 0
-          kubeReserved:
-            cpu: 700m
-            memory: 1024Mi
-          systemReserved:
-            cpu: 700m
-            memory: 1024Mi
+          registryPullQPS: 0 # since not available in the spec
 
     --BOUNDARY--
 
@@ -94,6 +88,10 @@ spec:
         karpenter.sh/discovery: "${flux_cluster_name}"
   detailedMonitoring: true
   associatePublicIPAddress: true
+  kubelet:
+    maxPods: 110
+    kubeReserved:
+      memory: 1465Mi # 255Mi + (11Mi * maxPods)
   userData: |
     MIME-Version: 1.0
     Content-Type: multipart/mixed; boundary="BOUNDARY"
@@ -103,9 +101,6 @@ spec:
 
     #!/bin/sh
     set -o xtrace
-
-    echo fs.inotify.max_user_watches=131072 | sudo tee -a /etc/sysctl.conf
-    sudo sysctl -p
 
     DOCKER_HUB_CREDS=$(aws ssm get-parameter --name /eks/${flux_cluster_name}/dockerhub --with-decrypt --query 'Parameter.Value' --output text)
     DOCKER_HUB_USER=$(echo "$DOCKER_HUB_CREDS" | jq .username)
@@ -127,13 +122,6 @@ spec:
     spec:
       kubelet:
         config:
-          maxPods: 110
-          registryPullQPS: 0
-          kubeReserved:
-            cpu: 700m
-            memory: 1024Mi
-          systemReserved:
-            cpu: 700m
-            memory: 1024Mi
+          registryPullQPS: 0 # since not available in the spec
 
     --BOUNDARY--


### PR DESCRIPTION
Avoid setting maxPods and kubeReserved in user_data, since it can lead to Karpenter not taking the extra reserved resources into account, when pulling in new nodes, leading to infinite loops of pulling in the same instance types with insufficient available resources.

Align learnings from this PR to Karpenter nodes https://github.com/dfds/infrastructure-modules/pull/2382