### PR TITLE
Increase Traefik resources

### DIFF
--- a/apps/traefik-blue-variant/manifests/Deployment-traefik-blue-variant.yml
+++ b/apps/traefik-blue-variant/manifests/Deployment-traefik-blue-variant.yml
@@ -43,10 +43,10 @@ spec:
           name: traefik-blue-variant
           resources:
             limits:
-              memory: 512Mi
+              memory: 640Mi
             requests:
-              cpu: 150m
-              memory: 512Mi
+              cpu: 200m
+              memory: 640Mi
           readinessProbe:
             httpGet:
               path: /ping
@@ -133,7 +133,7 @@ spec:
             - name: USER
               value: traefik
             - name: GOMEMLIMIT
-              value: "460MiB"
+              value: "576MiB"
       volumes:
         - name: data
           emptyDir: {}

--- a/apps/traefik-blue-variant/release.yaml
+++ b/apps/traefik-blue-variant/release.yaml
@@ -91,10 +91,10 @@ spec:
         enabled: true
     resources:
       limits:
-        memory: 512Mi
+        memory: 640Mi
       requests:
-        cpu: 150m
-        memory: 512Mi
+        cpu: 200m
+        memory: 640Mi
     service:
       enabled: true
       labels:

--- a/apps/traefik-green-variant/manifests/Deployment-traefik-green-variant.yml
+++ b/apps/traefik-green-variant/manifests/Deployment-traefik-green-variant.yml
@@ -43,10 +43,10 @@ spec:
           name: traefik-green-variant
           resources:
             limits:
-              memory: 512Mi
+              memory: 640Mi
             requests:
-              cpu: 150m
-              memory: 512Mi
+              cpu: 200m
+              memory: 640Mi
           readinessProbe:
             httpGet:
               path: /ping
@@ -133,7 +133,7 @@ spec:
             - name: USER
               value: traefik
             - name: GOMEMLIMIT
-              value: "460MiB"
+              value: "576MiB"
       volumes:
         - name: data
           emptyDir: {}

--- a/apps/traefik-green-variant/release.yaml
+++ b/apps/traefik-green-variant/release.yaml
@@ -89,10 +89,10 @@ spec:
         enabled: true
     resources:
       limits:
-        memory: 512Mi
+        memory: 640Mi
       requests:
-        cpu: 150m
-        memory: 512Mi
+        cpu: 200m
+        memory: 640Mi
     service:
       enabled: true
       labels:


### PR DESCRIPTION
The active Traefik pods ran at > 90% requested CPU and ~80% of memory limits, so we are increasing it a bit. See screenshot
<img width="1233" height="106" alt="image" src="https://github.com/user-attachments/assets/b7b27ece-f7e2-4ca5-aa59-56930e450664" />
