### PR TITLE
Migrate Traefik blue variant to be an IP aware targetgroup, with aws-lb-contorller handling bindings

### DIFF
--- a/apps/traefik-blue-variant/kustomization.yaml
+++ b/apps/traefik-blue-variant/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - namespace.yaml
   - sources.yaml
   - release.yaml
+  - targetgroupbindings.yaml

--- a/apps/traefik-blue-variant/manifests/Service-traefik-blue-variant.yml
+++ b/apps/traefik-blue-variant/manifests/Service-traefik-blue-variant.yml
@@ -12,8 +12,7 @@ metadata:
     scrape-service-metrics: "true"
   annotations:
 spec:
-  type: NodePort
-  externalTrafficPolicy: Cluster
+  type: ClusterIP
   selector:
     app.kubernetes.io/name: traefik
     app.kubernetes.io/instance: traefik-blue-variant-traefik-blue-variant
@@ -22,9 +21,7 @@ spec:
       name: traefik
       targetPort: traefik
       protocol: TCP
-      nodePort: ${flux_traefik_blue_target_admin_port}
     - port: 80
       name: web
       targetPort: web
       protocol: TCP
-      nodePort: ${flux_traefik_blue_target_http_port}

--- a/apps/traefik-blue-variant/namespace.yaml
+++ b/apps/traefik-blue-variant/namespace.yaml
@@ -5,3 +5,4 @@ metadata:
   name: traefik-blue-variant
   labels:
     pod-security.kubernetes.io/enforce: baseline
+    elbv2.k8s.aws/pod-readiness-gate-inject: enabled

--- a/apps/traefik-blue-variant/release.yaml
+++ b/apps/traefik-blue-variant/release.yaml
@@ -73,11 +73,9 @@ spec:
       traefik:
         expose:
           default: true
-        nodePort: ${flux_traefik_blue_target_admin_port}
       web:
         forwardedHeaders:
           insecure: true
-        nodePort: ${flux_traefik_blue_target_http_port}
       websecure:
         expose:
           default: false
@@ -99,6 +97,4 @@ spec:
       enabled: true
       labels:
         scrape-service-metrics: "true"
-      spec:
-        externalTrafficPolicy: Cluster
-      type: NodePort
+      type: ClusterIP

--- a/apps/traefik-blue-variant/targetgroupbindings.yaml
+++ b/apps/traefik-blue-variant/targetgroupbindings.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: elbv2.k8s.aws/v1beta1
+kind: TargetGroupBinding
+metadata:
+  name: alb-anon
+  namespace: traefik-blue-variant
+  annotations:
+    kustomize.toolkit.fluxcd.io/force: enabled
+spec:
+  serviceRef:
+    name: traefik-blue-variant
+    port: web
+  targetGroupARN: ${flux_alb_target_group_arn}
+  targetType: ip
+
+---
+apiVersion: elbv2.k8s.aws/v1beta1
+kind: TargetGroupBinding
+metadata:
+  name: alb-auth
+  namespace: traefik-blue-variant
+  annotations:
+    kustomize.toolkit.fluxcd.io/force: enabled
+spec:
+  serviceRef:
+    name: traefik-blue-variant
+    port: web
+  targetGroupARN: ${flux_alb_auth_target_group_arn}
+  targetType: ip


### PR DESCRIPTION
In our current setup all nodes are target for the load balancers in place exposing nodeports. The targetgroup registration is happening through an autoscalinggroup attachment. This makes all nodes go through a registration and deregistration process and adding on top of this all requests are very, very likely to make an extra network jump from the node to a node that actually has Traefik running.

Things done:
- change service type from nodeport to clusterip for Traefik blue variant
- add targetgroupbinding for registering Traefik blue pods to the correct targetgroup in AWS. Note that we are adding kustomize label to make sure the is overwritten because spec.targetGroupArn is immutable
- add readiness probe gate label to Traefik blue namespace to ensure that status ready for pods is only set if the pod is a healthy registered target for the targetgroup in AWS see https://kubernetes-sigs.github.io/aws-load-balancer-controller/v3.4/deploy/pod_readiness_gate/ for docs