### PR TITLE
Add/grafana/memory limits

### DIFF
--- a/apps/grafana/manifests/DaemonSet-grafana-k8s-monitoring-alloy-logs.yml
+++ b/apps/grafana/manifests/DaemonSet-grafana-k8s-monitoring-alloy-logs.yml
@@ -58,6 +58,12 @@ spec:
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
+          resources:
+            limits:
+              memory: 384Mi
+            requests:
+              cpu: 50m
+              memory: 384Mi
           volumeMounts:
             - name: config
               mountPath: /etc/alloy
@@ -91,3 +97,7 @@ spec:
         - name: varlog
           hostPath:
             path: /var/log
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 25%
+    type: RollingUpdate

--- a/apps/grafana/manifests/DaemonSet-grafana-k8s-monitoring-prometheus-node-exporter.yml
+++ b/apps/grafana/manifests/DaemonSet-grafana-k8s-monitoring-prometheus-node-exporter.yml
@@ -86,9 +86,11 @@ spec:
             successThreshold: 1
             timeoutSeconds: 1
           resources:
+            limits:
+              memory: 256Mi
             requests:
               cpu: 20m
-              memory: 50Mi
+              memory: 256Mi
           volumeMounts:
             - name: proc
               mountPath: /host/proc

--- a/apps/grafana/manifests/Deployment-grafana-k8s-monitoring-kube-state-metrics.yml
+++ b/apps/grafana/manifests/Deployment-grafana-k8s-monitoring-kube-state-metrics.yml
@@ -81,9 +81,11 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
           resources:
+            limits:
+              memory: 256Mi
             requests:
               cpu: 20m
-              memory: 100Mi
+              memory: 256Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/apps/grafana/manifests/StatefulSet-grafana-k8s-monitoring-alloy.yml
+++ b/apps/grafana/manifests/StatefulSet-grafana-k8s-monitoring-alloy.yml
@@ -92,6 +92,7 @@ spec:
             limits:
               memory: ${flux_grafana_agent_resource_memory}
             requests:
+              cpu: 200m
               memory: ${flux_grafana_agent_resource_memory}
           volumeMounts:
             - name: config

--- a/apps/grafana/release.yaml
+++ b/apps/grafana/release.yaml
@@ -146,18 +146,19 @@ spec:
                   values:
                   - observability
     alloy-logs:
+      alloy:
+        resources:
+          requests:
+            cpu: 50m
+            memory: 384Mi
+          limits:
+            memory: 384Mi
       controller:
         priorityClassName: node-observability
-      updateStrategy:
-        type: RollingUpdate
-        rollingUpdate:
-          maxUnavailable: 25%
-      resources:
-        requests:
-          cpu: 50m
-          memory: 384Mi
-        limits:
-          memory: 384Mi
+        updateStrategy:
+          type: RollingUpdate
+          rollingUpdate:
+            maxUnavailable: 25%
     metrics:
       enabled: true
       scrapeInterval: 120s

--- a/apps/grafana/release.yaml
+++ b/apps/grafana/release.yaml
@@ -97,6 +97,7 @@ spec:
               name: agent-wal
         resources:
           requests:
+            cpu: 200m
             memory: ${flux_grafana_agent_resource_memory}
           limits:
             memory: ${flux_grafana_agent_resource_memory}
@@ -151,6 +152,12 @@ spec:
         type: RollingUpdate
         rollingUpdate:
           maxUnavailable: 25%
+      resources:
+        requests:
+          cpu: 50m
+          memory: 384Mi
+        limits:
+          memory: 384Mi
     metrics:
       enabled: true
       scrapeInterval: 120s
@@ -215,7 +222,9 @@ spec:
       resources:
         requests:
           cpu: 20m
-          memory: 100Mi
+          memory: 256Mi
+        limits:
+          memory: 256Mi
       priorityClassName: cluster-observability
       rbac:
         create: true
@@ -244,7 +253,9 @@ spec:
       resources:
         requests:
           cpu: 20m
-          memory: 50Mi
+          memory: 256Mi
+        limits:
+          memory: 256Mi
       priorityClassName: node-observability
       updateStrategy:
         type: RollingUpdate


### PR DESCRIPTION
Fixes minor issues found related to Grafana workloads missing resources or rightsizing. Also found that rolloutstrategy was set wrong in the values.

* Set resources for alloy-logs daemonSet
* Set rolloutstrategy correct in the values file for alloy-logs. This is important for speedy daemonSet rollouts for large clusters
* Rightsize memory and set limit on kube-state-metrics
* Rightsize memory and set limit on node-exporter
* Set cpu request for alloy statefulset
