### PR TITLE
Redis recommends 5x of memory allocated as volume size. Since we have maxmemory set, we will 5x that in stead

### DIFF
--- a/apps/falco/manifests/ConfigMap-falco-falcosidekick-ui-redis.yml
+++ b/apps/falco/manifests/ConfigMap-falco-falcosidekick-ui-redis.yml
@@ -14,7 +14,7 @@ metadata:
 data:
   redis-stack.conf: |-
     maxmemory-policy allkeys-lfu
-    maxmemory 2024mb
+    maxmemory 2048mb
   ping-redis.sh: |-
     #!/bin/bash
     for i in {1..10};

--- a/apps/falco/manifests/StatefulSet-falco-falcosidekick-ui-redis.yml
+++ b/apps/falco/manifests/StatefulSet-falco-falcosidekick-ui-redis.yml
@@ -84,4 +84,4 @@ spec:
         accessModes: ["ReadWriteOnce"]
         resources:
           requests:
-            storage: 1Gi
+            storage: 10Gi

--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -62,10 +62,10 @@ spec:
             memory: 64Mi
         redis:
           priorityClassName: cluster-observability
-          storageSize: "1Gi"
+          storageSize: "10Gi" # needs to 5x larger than maxmeory
           customConfig:
             - maxmemory-policy allkeys-lfu # evict the least frequently used (LFU) keys
-            - maxmemory 2024mb
+            - maxmemory 2048mb
           resources:
             requests:
               cpu: 250m


### PR DESCRIPTION
Set maxmemory to intended size so 2048mb and not 2024mb, which is a typo.

Increase PVC size to recommended size, which i 5x of allocated memory. In this case we use maxmory in stead of actual memory. See https://redis.io/docs/latest/operate/kubernetes/recommendations/persistent-volumes/#volume-size

See screenshot for production actual usage.
<img width="1517" height="412" alt="image" src="https://github.com/user-attachments/assets/dc611f06-77fa-4fb3-87b3-e6b92958e114" />

We also see this error in logs

```
2026-07-22T09:36:52.409765951Z falco-falco-falcosidekick-ui-redis-0 1638:C 22 Jul 2026 09:36:52.409 # Write error while saving DB to the disk(rdbSaveRio): No space left on device
2026-07-22T09:36:52.576013311Z falco-falco-falcosidekick-ui-redis-0 9:M 22 Jul 2026 09:36:52.575 # Background saving error
```