### PR TITLE
Kube-state-metrics was OOM'ing beause of spiky memory usage on restarts

### DIFF
--- a/apps/grafana/manifests/Deployment-grafana-k8s-monitoring-kube-state-metrics.yml
+++ b/apps/grafana/manifests/Deployment-grafana-k8s-monitoring-kube-state-metrics.yml
@@ -82,10 +82,10 @@ spec:
             timeoutSeconds: 5
           resources:
             limits:
-              memory: 256Mi
+              memory: 1Gi
             requests:
               cpu: 20m
-              memory: 256Mi
+              memory: 1Gi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/apps/grafana/release.yaml
+++ b/apps/grafana/release.yaml
@@ -223,9 +223,9 @@ spec:
       resources:
         requests:
           cpu: 20m
-          memory: 256Mi
+          memory: 1Gi
         limits:
-          memory: 256Mi
+          memory: 1Gi
       priorityClassName: cluster-observability
       rbac:
         create: true


### PR DESCRIPTION
Bump kube-state-metrics memory request and limit to 1Gi to avoid OOM'ing on pod restarts

![Uploading image.png…]()
