### PR TITLE
Increase/falco/redis memory

### DIFF
--- a/apps/falco/manifests/StatefulSet-falco-falcosidekick-ui-redis.yml
+++ b/apps/falco/manifests/StatefulSet-falco-falcosidekick-ui-redis.yml
@@ -63,10 +63,10 @@ spec:
               subPath: redis-stack.conf
           resources:
             limits:
-              memory: 2560Mi
+              memory: 3Gi
             requests:
               cpu: 250m
-              memory: 2560Mi
+              memory: 3Gi
       volumes:
         - name: config
           configMap:

--- a/apps/falco/release.yaml
+++ b/apps/falco/release.yaml
@@ -69,9 +69,9 @@ spec:
           resources:
             requests:
               cpu: 250m
-              memory: 2560Mi
+              memory: 3Gi
             limits:
-              memory: 2560Mi
+              memory: 3Gi
     resources:
       requests:
         cpu: 50m


### PR DESCRIPTION
Here is a graph of mermory usage while it was OOM'ing and after I manually bumped it to 3Gi around 7:20 UTC

<img width="1521" height="266" alt="image" src="https://github.com/user-attachments/assets/b572e40e-f2af-4dd5-b28d-c6785f2ccfbd" />
