### PR TITLE
whitelist node metric in grafana node exporter

### DIFF
--- a/apps/grafana/manifests/ConfigMap-grafana-k8s-monitoring-alloy.yml
+++ b/apps/grafana/manifests/ConfigMap-grafana-k8s-monitoring-alloy.yml
@@ -526,6 +526,11 @@ data:
         regex = "up|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|node_network_receive_bytes_total|node_network_receive_drop_total|node_network_transmit_bytes_total|node_network_transmit_drop_total|process_cpu_seconds_total|process_resident_memory_bytes"
         action = "keep"
       }
+      rule {
+        source_labels = ["__name__"]
+        regex = "node_sockstat_sockets_used"
+        action = "drop"
+      }
       // Drop metrics for certain file systems
       rule {
         source_labels = ["__name__", "fstype"]

--- a/apps/grafana/manifests/ConfigMap-grafana-k8s-monitoring-alloy.yml
+++ b/apps/grafana/manifests/ConfigMap-grafana-k8s-monitoring-alloy.yml
@@ -523,13 +523,8 @@ data:
       max_cache_size = 100000
       rule {
         source_labels = ["__name__"]
-        regex = "up|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|node_network_receive_bytes_total|node_network_receive_drop_total|node_network_transmit_bytes_total|node_network_transmit_drop_total|process_cpu_seconds_total|process_resident_memory_bytes"
+        regex = "up|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|node_network_receive_bytes_total|node_network_receive_drop_total|node_network_transmit_bytes_total|node_network_transmit_drop_total|process_cpu_seconds_total|process_resident_memory_bytes|node_sockstat_sockets_used"
         action = "keep"
-      }
-      rule {
-        source_labels = ["__name__"]
-        regex = "node_sockstat_sockets_used"
-        action = "drop"
       }
       // Drop metrics for certain file systems
       rule {

--- a/apps/grafana/manifests/ConfigMap-validate-grafana-k8s-monitoring.yml
+++ b/apps/grafana/manifests/ConfigMap-validate-grafana-k8s-monitoring.yml
@@ -530,13 +530,8 @@ data:
       max_cache_size = 100000
       rule {
         source_labels = ["__name__"]
-        regex = "up|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|node_network_receive_bytes_total|node_network_receive_drop_total|node_network_transmit_bytes_total|node_network_transmit_drop_total|process_cpu_seconds_total|process_resident_memory_bytes"
+        regex = "up|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|node_network_receive_bytes_total|node_network_receive_drop_total|node_network_transmit_bytes_total|node_network_transmit_drop_total|process_cpu_seconds_total|process_resident_memory_bytes|node_sockstat_sockets_used"
         action = "keep"
-      }
-      rule {
-        source_labels = ["__name__"]
-        regex = "node_sockstat_sockets_used"
-        action = "drop"
       }
       // Drop metrics for certain file systems
       rule {

--- a/apps/grafana/manifests/ConfigMap-validate-grafana-k8s-monitoring.yml
+++ b/apps/grafana/manifests/ConfigMap-validate-grafana-k8s-monitoring.yml
@@ -533,6 +533,11 @@ data:
         regex = "up|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|node_network_receive_bytes_total|node_network_receive_drop_total|node_network_transmit_bytes_total|node_network_transmit_drop_total|process_cpu_seconds_total|process_resident_memory_bytes"
         action = "keep"
       }
+      rule {
+        source_labels = ["__name__"]
+        regex = "node_sockstat_sockets_used"
+        action = "drop"
+      }
       // Drop metrics for certain file systems
       rule {
         source_labels = ["__name__", "fstype"]

--- a/apps/grafana/release.yaml
+++ b/apps/grafana/release.yaml
@@ -170,7 +170,7 @@ spec:
         enabled: true
         metricsTuning:
           useDefaultAllowList: true
-          excludeMetrics:
+          includeMetrics:
             - node_sockstat_sockets_used
       serviceMonitors:
         enabled: true

--- a/apps/grafana/release.yaml
+++ b/apps/grafana/release.yaml
@@ -170,6 +170,8 @@ spec:
         enabled: true
         metricsTuning:
           useDefaultAllowList: true
+          excludeMetrics:
+            - node_sockstat_sockets_used
       serviceMonitors:
         enabled: true
         selector:


### PR DESCRIPTION
missing metric about node socket causing triggering of alert "No Data"

<img width="2745" height="671" alt="image" src="https://github.com/user-attachments/assets/e7ca66b3-2995-4c22-8fde-cbc4378582eb" />

Looks like it has been disabled half year ago.

<img width="2860" height="859" alt="image" src="https://github.com/user-attachments/assets/2beb9979-ffdd-408d-b866-d59a1c4b0fa9" />
