### PR TITLE
add missing velero metric to fix DatasourceNoData alert

### DIFF
--- a/apps/velero/release.yaml
+++ b/apps/velero/release.yaml
@@ -85,7 +85,7 @@ spec:
         enabled: true
         metricRelabelings:
         - action: keep
-          regex: velero_backup_validation_failure_total|velero_restore_failed_total|velero_restore_validation_failed_total|velero_volume_snapshot_failure_total
+          regex: velero_backup_validation_failure_total|velero_restore_failed_total|velero_restore_validation_failed_total|velero_volume_snapshot_failure_total|velero_restore_partial_failure_total
           sourceLabels:
           - __name__
     priorityClassName: cluster-infrastructure


### PR DESCRIPTION
This PR Adds `velero_restore_partial_failure_total` to the list of metrics included by the `metricRelabelings` filter in `apps/velero/release.yaml`, ensuring partial restore failures are now tracked.

Missing this metric causes the alert to trigger on DatasourceNoData and it has missing since December 2025 from this commit https://github.com/dfds/platform-apps/commit/dc2af1b5249f61647b19f24e75cab2f33c6ddd07

Query:
<img width="2421" height="813" alt="image" src="https://github.com/user-attachments/assets/68a73cbf-812f-4a2d-bfa6-c07a24650cf0" />

Alert:
<img width="669" height="318" alt="image" src="https://github.com/user-attachments/assets/c079cdcf-4586-4818-93f5-e770afa6b884" />
