### PR TITLE
Update karpenter EC2NodeClass to use latest AMI v20260810

### DIFF
--- a/apps/karpenter-nodes/classes/al2023.yaml
+++ b/apps/karpenter-nodes/classes/al2023.yaml
@@ -15,7 +15,7 @@ spec:
   role: "karpenter-${flux_cluster_name}"
   amiFamily: AL2023
   amiSelectorTerms:
-    - alias: "al2023@v20260618"
+    - alias: "al2023@v20260810"
   subnetSelectorTerms:
     - tags:
         karpenter.sh/discovery: "${flux_cluster_name}"


### PR DESCRIPTION
Karpenter nodes should follow eks-pipeline defined AMI.

ASSISTED-BY: QWEN 3.5